### PR TITLE
Sieve planes and optics target

### DIFF
--- a/src/hms/mc_hms.f
+++ b/src/hms/mc_hms.f
@@ -1,4 +1,4 @@
-	subroutine mc_hms (p_spec, th_spec, dpp, x, y, z, dxdz, dydz,
+  	subroutine mc_hms (p_spec, th_spec, dpp, x, y, z, dxdz, dydz,
      >		x_fp, dx_fp, y_fp, dy_fp, m2,
      >		ms_flag, wcs_flag, decay_flag, resmult, fry, ok_spec, pathlen)
 
@@ -51,7 +51,7 @@ C Spectrometer definitions - for double arm monte carlo compatability
 ! should still be pretty good for optics. Physics limits (e.g. elastic
 ! peak at x<=1) will not be preserved.
 
-	logical use_sieve /.true./		!use a fake sieve slit.
+	logical use_sieve /.false./		!use a fake sieve slit.
 
 ! Variables so that events are not forced through sieve
 	real*8 xs_num, ys_num, xc_sieve, yc_sieve
@@ -86,7 +86,8 @@ c	parameter (z_off=+1.50)		!1996 position
 	parameter (z_off=+40.17)	!HMS100 tune (dg 5/27/98)
 
 ! z-position of important apertures.
-	real*8 z_entr,z_exit
+	real*8 z_entr,z_exit, sieve_tk
+        parameter (sieve_tk = 1.25*2.54)         !sieve thick=1.25"  
 	parameter (z_entr = 126.2e0 + z_off)	!nominally 1.262 m
 	parameter (z_exit = z_entr + 6.3e0)	!6.3 cm thick
 
@@ -125,6 +126,7 @@ c	parameter (z_off=+1.50)		!1996 position
 	real*8 y_recon
 	real*8 p,m2				!More kinematic variables.
 	real*8 xt,yt,rt,tht			!temporaries
+	real*8 xt_bs,yt_bs                      !pos at back of sieve 
 	real*8 resmult				!DC resolution factor
 	real*8 zdrift
 
@@ -163,16 +165,26 @@ C ================================ Executable Code =============================
 !	  dydz = (yt-y)/z_entr
 !	endif
 
+
 	if (use_sieve) then
 	   xt = x + z_entr *dxdz
 	   yt = y + z_entr *dydz
 	   xs_num = anint(xt/2.54)
 	   ys_num = anint(yt/1.524)
-	   xc_sieve = 2.54*xs_num
-	   yc_sieve = 1.524*ys_num
+	   xc_sieve = 2.54*xs_num   
+	   yc_sieve = 1.524*ys_num  
 	   if ( sqrt((xc_sieve - xt)**2+(yc_sieve - yt)**2) .gt. 0.3) then
 	      goto 500
 	   endif
+           
+! Check at back of sieve
+           xt_bs = xt + sieve_tk *dxdz
+           yt_bs = yt + sieve_tk *dydz
+	   if ( sqrt((xc_sieve - xt_bs)**2+(yc_sieve - yt_bs)**2) .gt. 0.3) then
+	      goto 500
+	   endif
+
+! Save pos. at front of sieve
 	   xc_sieve = xt
 	   yc_sieve = yt
 	endif

--- a/src/hms/mc_hms.f
+++ b/src/hms/mc_hms.f
@@ -51,10 +51,14 @@ C Spectrometer definitions - for double arm monte carlo compatability
 ! should still be pretty good for optics. Physics limits (e.g. elastic
 ! peak at x<=1) will not be preserved.
 
-	logical use_sieve /.false./		!use a fake sieve slit.
-
-! Variables so that events are not forced through sieve
 	real*8 xs_num, ys_num, xc_sieve, yc_sieve
+	real*8 xsfr_num, ysfr_num, xc_frsieve, yc_frsieve
+	logical use_sieve, use_front_sieve		
+
+        common /sieve_info/ xs_num,ys_num,xc_sieve,yc_sieve
+     > ,xsfr_num,ysfr_num,xc_frsieve,yc_frsieve,use_sieve, use_front_sieve
+         
+! Variables so that events are not forced through sieve
 
 ! No collimator - wide open
 !	parameter (h_entr = 99.)

--- a/src/mc_single_arm.f
+++ b/src/mc_single_arm.f
@@ -22,7 +22,7 @@ c
 	real*8 xs_num,ys_num,xc_sieve,yc_sieve
 	real*8 xsfr_num,ysfr_num,xc_frsieve,yc_frsieve
         logical use_front_sieve /.false./
-        logical use_sieve /.false./ 
+        logical use_sieve /.false./            !Also set in mc_hms.f
 c
         common /sieve_info/  xs_num,ys_num,xc_sieve,yc_sieve
      > ,xsfr_num,ysfr_num,xc_frsieve,yc_frsieve,use_sieve
@@ -58,6 +58,8 @@ C Event limits, topdrawer limits, physics quantities
 
 	real*8 x_a,y_a,z_a,dydz_a,dif_a,dydz_aa,dif_aa   ! TH - for target aperture check
 	real*8 musc_targ_len			!target length for multiple scattering
+        real*8 foil_nm, foil_tk                 !multifoil target
+        parameter (foil_tk=0.02)
 	real*8 m2				!particle mass squared.
 	real*8 rad_len_cm			!conversion r.l. to cm for target
 	real*8 pathlen				!path length through spectrometer.
@@ -442,8 +444,21 @@ C Units are cm.
 ! TH - use a double precision for random number generation here.
 	  x = gauss1(th_nsig_max) * gen_lim(4) / 6.0	!beam width
 	  y = gauss1(th_nsig_max) * gen_lim(5) / 6.0	!beam height
-	  z = (grnd() - 0.5) * gen_lim(6)		!along target
 
+          if(gen_lim(6).gt.0) then                      
+	     z = (grnd() - 0.5) * gen_lim(6)		!along target
+
+          elseif(gen_lim(6).eq.-3) then                 !optics1: three foils
+             foil_nm=3*grnd()-1.5                       !20um foils;  z=0, +/- 10cm
+             foil_nm=anint(foil_nm)                     != -1, 0, 1
+	     z = (grnd() - 0.5) * foil_tk + foil_nm * 10
+
+          elseif(gen_lim(6).eq.-2) then                 !optics2: two foils
+             foil_nm=grnd()                             !20um foils; z= +/- 5cm
+             foil_nm=anint(foil_nm)                     != 0, 1
+	     z = (grnd() - 0.5) * foil_tk - 5+ foil_nm * 10
+
+          endif
 C DJG Assume flat raster
 	  fr1 = (grnd() - 0.5) * gen_lim(7)   !raster x
 	  fr2 = (grnd() - 0.5) * gen_lim(8)   !raster y

--- a/src/mc_single_arm.f
+++ b/src/mc_single_arm.f
@@ -25,7 +25,7 @@ c
         logical use_sieve /.false./            !Also set in mc_hms.f
 c
         common /sieve_info/  xs_num,ys_num,xc_sieve,yc_sieve
-     > ,xsfr_num,ysfr_num,xc_frsieve,yc_frsieve,use_sieve
+     > ,xsfr_num,ysfr_num,xc_frsieve,yc_frsieve,use_sieve, use_front_sieve
 
 
 C Local declarations.

--- a/src/shms/mc_shms.f
+++ b/src/shms/mc_shms.f
@@ -55,7 +55,7 @@ C Math constants
 ! should still be pretty good for optics. Physics limits (e.g. elastic
 ! peak at x<=1) will not be preserved.
 
-	logical use_front_sieve /.false./ 
+C	logical use_front_sieve /.false./ 
 c 	logical use_sieve /.true./ 
 c        logical use_coll /.false./ ! use collimator
         logical use_coll /.false./ ! use collimator, set to false if using sieve
@@ -69,9 +69,10 @@ c
 	real*8 xt_bs, yt_bs, sieve_tk
 	real*8 xsfr_num,ysfr_num,xc_frsieve,yc_frsieve
         logical use_sieve                      !set in mc-single-arm.f
+        logical use_front_sieve                !use front sieve
 c
         common /sieve_info/  xs_num,ys_num,xc_sieve,yc_sieve
-     > ,xsfr_num,ysfr_num,xc_frsieve,yc_frsieve,use_sieve
+     > ,xsfr_num,ysfr_num,xc_frsieve,yc_frsieve,use_sieve, use_front_sieve
 C The arguments
 
 	real*8	x,y,z				!(cm)

--- a/src/shms/mc_shms.f
+++ b/src/shms/mc_shms.f
@@ -66,8 +66,9 @@ c        logical use_coll /.false./ ! use collimator
         logical skip_hb /.false./
 c
 	real*8 xs_num,ys_num,xc_sieve,yc_sieve
+	real*8 xt_bs, yt_bs, sieve_tk
 	real*8 xsfr_num,ysfr_num,xc_frsieve,yc_frsieve
-        logical use_sieve
+        logical use_sieve                      !set in mc-single-arm.f
 c
         common /sieve_info/  xs_num,ys_num,xc_sieve,yc_sieve
      > ,xsfr_num,ysfr_num,xc_frsieve,yc_frsieve,use_sieve
@@ -179,6 +180,7 @@ c        parameter(zd_fp    = 307.95)
 
 
 C Distances for 2017 ME's
+        parameter (sieve_tk = 1.25*2.54)         !sieve thick=1.25"  
         parameter(zd_fr_sieve  = 108.0)
         parameter(zd_hbin  = 118.39)
 	parameter(zd_hbmen = 17.61) ! shms-2017 ME's
@@ -420,6 +422,7 @@ c sieve in front of HB
            spec(8)=yt
           endif
 
+	  
           if (use_sieve ) then
   	   zdrift = z_entr
            xt=xs + zdrift*dxdzs
@@ -431,10 +434,20 @@ c sieve in front of HB
            if ( sqrt((xc_sieve - xt)**2+(yc_sieve - yt)**2) .gt. 0.3) then
               goto 500
            endif
-	   xc_sieve=xt
-	   yc_sieve=yt
-          endif
-! simulate collimator -------------------------------------------------
+
+! Check at back of sieve
+           xt_bs = xt + sieve_tk*dxdzs
+           yt_bs = yt + sieve_tk*dydzs
+	   if ( sqrt((xc_sieve - xt_bs)**2+(yc_sieve - yt_bs)**2) .gt. 0.3) then
+	      goto 500
+	   endif
+
+! Save pos. at front of sieve
+	   xc_sieve = xt
+	   yc_sieve = yt
+	endif
+
+!simulate collimator -------------------------------------------------
 c
           if (use_coll) then
 c           tpathlen=pathlen


### PR DESCRIPTION
*Adds a second sieve plane to account for their thickness in both the shms and hms. 
*Adds two and three foil optics target.  Implemented by changing thickness to -2 or -3 in the input file    