### PR TITLE
Jixie's changes to increase the hbook file size

### DIFF
--- a/src/hms_hbook_init.f
+++ b/src/hms_hbook_init.f
@@ -6,9 +6,11 @@ C HBOOK/NTUPLE common block and parameters.
       character*80 filename
       logical*4 spec_ntuple
       integer*4	pawc_size
-      parameter	(pawc_size = 1000000)
+      parameter	(pawc_size = 10000000)
       common		/pawc/ hbdata(pawc_size)
       integer*4	hbdata
+      common /QUEST/ iquest(100)
+      integer*4 iquest
       character*8	hut_nt_names(21)/
      >     'hsxfp', 'hsyfp', 'hsxpfp', 'hsypfp',
      >     'hsxtari','hsytari','hsxptari','hsyptari',
@@ -18,13 +20,27 @@ C HBOOK/NTUPLE common block and parameters.
 
       call hlimit(pawc_size)
 
-cmkj      iquest(10) = 256000
-cmkj	  iquest(10) = 510000
-! see for example
+c By Jixie: to create a large ntuple, we need to do the following 4 things:
+c  1) CALL hlimit(pawc_size) with a big argument (set 'pawc_size' to a big value). 
+c  2) set 'iquest(10)' to a big number, this value means the maximum records.
+c     Important note: It is very important to initialise IQUEST(10) just before
+c     the call to HROPEN. The QUEST common block is used a lot in the whole CERNLIB,
+c     and in particular in HBOOK, so if the value of IQUEST(10) is defined too far
+c     from the call to HROPEN, very likely it will not have the expected value when
+c     needed. 
+c  3) CALL HROPEN with a large value of LRECL (ex LRECL=4096 instead of 1024)
+c     and you can get files 4 times bigger. This value means the maximum words
+c     in one record.
+c  4) CALL HROPEN with the option QE (E for "Extended"). This option allows to
+c     have up to 2**32 records in an HBOOK file.
+c  By default, no nutuple will be larger than 2G Bytes. Other place need to be
+c  changed if you want that happen.
+c  Check https://userweb.jlab.org/~brads/Manuals/pawfaq/ for details
+!  also see for example
 !   http://wwwasd.web.cern.ch/wwwasd/cgi-bin/listpawfaqs.pl/7
-! the file size is limited to ~260M no matter how I change iquest !
-cmkj	  call hropen(30,'HUT',filename,'NQ',4096,i) !CERNLIB
-      call hropen(30,'HUT',filename,'N',4096,i) !CERNLIB
+
+      iquest(10) = 512000
+      call hropen(30,'HUT',filename,'NQE',4096,i) !CERNLIB
  
       if (i.ne.0) then
          write(*,*),'HROPEN error: istat = ',i

--- a/src/shms_hbook_init.f
+++ b/src/shms_hbook_init.f
@@ -6,9 +6,11 @@ C HBOOK/NTUPLE common block and parameters.
       character*80 filename
       logical*4 spec_ntuple
       integer*4	pawc_size
-      parameter	(pawc_size = 1000000)
+      parameter	(pawc_size = 10000000)
       common		/pawc/ hbdata(pawc_size)
-      integer*4	hbdata
+      integer*4 hbdata
+      common /QUEST/ iquest(100)
+      integer*4 iquest
       character*8	hut_nt_names(21)/
      >     'psxfp', 'psyfp', 'psxpfp', 'psypfp',
      >     'psztari','psytari', 'psdeltai', 'psyptari', 'psxptari',
@@ -35,14 +37,27 @@ C HBOOK/NTUPLE common block and parameters.
 
 
       call hlimit(pawc_size)
-
-cmkj      iquest(10) = 256000
-cmkj	  iquest(10) = 510000
-! see for example
+c By Jixie: to create a large ntuple, we need to do the following 4 things:
+c  1) CALL hlimit(pawc_size) with a big argument (set 'pawc_size' to a big value). 
+c  2) set 'iquest(10)' to a big number, this value means the maximum records.
+c     Important note: It is very important to initialise IQUEST(10) just before
+c     the call to HROPEN. The QUEST common block is used a lot in the whole CERNLIB,
+c     and in particular in HBOOK, so if the value of IQUEST(10) is defined too far
+c     from the call to HROPEN, very likely it will not have the expected value when
+c     needed. 
+c  3) CALL HROPEN with a large value of LRECL (ex LRECL=4096 instead of 1024)
+c     and you can get files 4 times bigger. This value means the maximum words
+c     in one record.
+c  4) CALL HROPEN with the option QE (E for "Extended"). This option allows to
+c     have up to 2**32 records in an HBOOK file.
+c  By default, no nutuple will be larger than 2G Bytes. Other place need to be
+c  changed if you want that happen.
+c  Check https://userweb.jlab.org/~brads/Manuals/pawfaq/ for details
+!  also see for example
 !   http://wwwasd.web.cern.ch/wwwasd/cgi-bin/listpawfaqs.pl/7
-! the file size is limited to ~260M no matter how I change iquest !
-cmkj	  call hropen(30,'HUT',filename,'NQ',4096,i) !CERNLIB
-      call hropen(30,'HUT',filename,'N',4096,i) !CERNLIB
+
+      iquest(10) = 512000
+      call hropen(30,'HUT',filename,'NQE',4096,i) !CERNLIB
  
       if (i.ne.0) then
          write(*,*),'HROPEN error: istat = ',i


### PR DESCRIPTION
Before the changes the I found the max file size to be 500Mb.  Additionally when the files reached ~350Mb I was getting the following warning:

RZOUT: current RZ file cannot support > 64K records or individual directories > 64K
RZOUT: previous cycle(s) for this key (       1)  deleted
RZOUT: please consult ZEBRA manual for further details

After the changes the warning stopped and files larger than 500Mb could be made.