### PR TITLE
Fixed typo which was not allowing spec. x-offset to be printed 

### DIFF
--- a/src/mc_single_arm.f
+++ b/src/mc_single_arm.f
@@ -353,7 +353,7 @@ C Strip off header
 
 ! Spectrometer offsets
 	read (chanin, 1001) str_line
-	write(8,*),str_line(1:last_char(str_line))
+	write(*,*),str_line(1:last_char(str_line))
 	iss = rd_real(str_line,spec_xoff)
 	if(.not.iss) stop 'ERROR (spect. xoff) in setup!'
 


### PR DESCRIPTION
Fixed typo which was not allowing spec. x-offset to be printed after reading infile