### PR TITLE
Updated mc_hms call in mc_single_arm.f

### DIFF
--- a/src/mc_single_arm.f
+++ b/src/mc_single_arm.f
@@ -687,7 +687,7 @@ c            if (ok_spec) spec(58) =1.
 	     call mc_hms(p_spec, th_spec, dpp_s, x_s, y_s, z_s, 
      >          dxdz_s, dydz_s,
      >          x_fp, dx_fp, y_fp, dy_fp, m2,
-     >          ms_flag, wcs_flag, decay_flag, resmult, fry, ok_spec, 
+     >          ms_flag, wcs_flag, decay_flag, resmult, xtar_init, ok_spec, 
      >          pathlen)
 	  else
 	     write(6,*) 'Unknown spectrometer! Stopping..'


### PR DESCRIPTION
The mc_hms call was passing fry, the vertical
beam position, for the
vertical target position.

It should pass the xtar_init which is
tthe vertical target position at the z=0 plane
which includes fry.

The xtar_init is used for the xtar dependent
corrections in the recon matrix.

Ideally one would calculate the xtar and the recon matrix in
an iterative approach to mimic what  is done in HCANA.