### PR TITLE
Modify musc_ext.f

### DIFF
--- a/src/shared/musc_ext.f
+++ b/src/shared/musc_ext.f
@@ -1,4 +1,4 @@
-	subroutine musc_ext(m2,p,rad_len,x_len,dth,dph,y,x)
+	subroutine musc_ext(m2,p,rad_len,x_len,dph,dth,y,x)
 C+_____________________________________________________________________
 !
 ! MUSC - Simulate multiple scattering of any particle.


### PR DESCRIPTION
In musc_ext.f
subroutine musc_ext(m2,p,rad_len,x_len,dth,dph,y,x)
 and in calculations in the code
 dth is associated with x and dph is associated with y.

Unfortunately all calls in the spectrometer codes
are like
call musc_ext(m2,p,radw,drift,dydzs,dxdzs,ys,xs)
which would put dydzs with xs and dxdzs with ys.

Since this mistake is the same in all calls to
musc_ext in all spectrometers, it is easier
to change the order
in the subroutine arguments to
musc_ext(m2,p,rad_len,x_len,dph,dth,y,x)