### PR TITLE
added stop_id = 36 for events that dies in the HMS hut

### DIFF
--- a/src/hms/mc_hms.f
+++ b/src/hms/mc_hms.f
@@ -463,7 +463,10 @@ C------------------------------------------------------------------------------C
 	  zdrift = driftdist(spectr,12) - z_dip3	!distance left to go.
 	  call mc_hms_hut(m2,p,x_fp,dx_fp,y_fp,dy_fp,ms_flag,wcs_flag,
      >		decay_flag,dflag,resmult,ok,-zdrift,pathlen)
-	  if (.not.ok) goto 500
+	  if (.not.ok) then 
+	     hSTOP_id = 36
+	     goto 500
+	  endif
 
 ! replace xs,ys,... with 'tracked' quantities.
 	  xs=x_fp


### PR DESCRIPTION
Events in the HMS that didn't make it through the detector checks (mc_hms_hut.f) had a stop_id == 0.  Furthermore, the reconstructed quantities for these events were never calculated.  I think the reconstructed value defaults to the last ok_spec event.

Now events that fail the detector geometry checks are given a unique stop_id, like what is done for the SHMS.   