### PR TITLE
Updates for rhel9/alma9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ mc_single_arm
 ==============
 Update: May 15, 2024
 
-Removed cernlib dependency for easir RHEL9/Alma9 compatibility.  Output is now fortran binary file.  Separate applications in "util" directory can make either ntuples or root trees. These applications must be compiled separately. Scripts in top directory will generate fortran binary file, run appropriate application to create ntuple/tree, and delete binary file (run_mc_single_arm_ntup and run_mc_single_arm_tree).
+Removed cernlib dependency for easier RHEL9/Alma9 compatibility.  Output is now fortran binary file.  Separate applications in "util" directory can make either ntuples or root trees. These applications must be compiled separately. Scripts in top directory will generate fortran binary file, run appropriate application to create ntuple/tree, and delete binary file (run_mc_single_arm_ntup and run_mc_single_arm_tree).
 
 ***********
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 mc_single_arm
 ==============
+Update: May 15, 2024
+
+Removed cernlib dependency for easir RHEL9/Alma9 compatibility.  Output is now fortran binary file.  Separate applications in "util" directory can make either ntuples or root trees. These applications must be compiled separately. Scripts in top directory will generate fortran binary file, run appropriate application to create ntuple/tree, and delete binary file (run_mc_single_arm_ntup and run_mc_single_arm_tree).
+
+***********
 
 Hall C single arm Monte Carlo for HMS and SHMS 
-
-
 
 To compile type "make" in the src directory.
 NOTE: Make sure paths to Cern libararies are defined.

--- a/run_mc_single_arm_ntup
+++ b/run_mc_single_arm_ntup
@@ -3,3 +3,9 @@ cd src
 ./mc_single_arm << endofinput >! ../runout/$1.out
 $1
 endofinput
+cd ../util/ntuple
+./make_ntuple << endofinput
+$1
+endofinput
+cd ../..
+rm worksim/$1.bin

--- a/run_mc_single_arm_tree
+++ b/run_mc_single_arm_tree
@@ -1,0 +1,11 @@
+#!/usr/bin/tcsh 
+cd src
+./mc_single_arm << endofinput >! ../runout/$1.out
+$1
+endofinput
+cd ../util/root_tree
+./make_root_tree << endofinput
+$1
+endofinput
+cd ../..
+rm worksim/$1.bin

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,7 @@ SHELL     = /bin/sh
 H      = hms/
 SH      = shms/
 SHARE	  = shared/
+CH	= cern/
 
 my_objs = hms_hbook_init.o shms_hbook_init.o \
           target_cans.o \
@@ -16,6 +17,7 @@ my_objs = hms_hbook_init.o shms_hbook_init.o \
 	  $(SHARE)project.o $(SHARE)transp.o $(SHARE)rotate_haxis.o \
 	  $(SHARE)rotate_vaxis.o $(SHARE)locforunt.o $(SHARE)musc.o \
           $(SHARE)musc_ext.o $(SHARE)stringlib.o mt19937.o gauss1.o \
+	  $(CH)lfit.o $(CH)ranlux.o $(CH)fint.o $(CH)kerset.o $(CH)abend.o \
           loren.o
 
 MYOS := $(subst -,,$(shell uname))
@@ -23,7 +25,7 @@ MYOS := $(subst -,,$(shell uname))
 
 
 #CERNLIBS = -lgeant$(GEANTVER) -lpawlib -lgraflib -lgrafX11 -lpacklib -lmathlib
-CERNLIBS = -lpawlib -lgraflib -lgrafX11 -lpacklib -lmathlib
+#CERNLIBS = -lpawlib -lgraflib -lgrafX11 -lpacklib -lmathlib
 
 ifeq ($(MYOS),HPUX)
   ifneq (,$(findstring 09,$(shell uname -r)))
@@ -100,7 +102,8 @@ ifeq ($(MYOS),Linux)
 #  INCLUDES=-I.,..,./sos,$(SH),./hrsr,./hrsl,./shms,$(Csoft)/INCLUDE
   FFLAGS= $(INCLUDES) $(FFLAGSA)
   FFLAG1=$(FFLAGS) -c
-  OTHERLIBS =  -L$(CERN_ROOT)/lib $(CERNLIBS) -L/usr/lib
+#  OTHERLIBS =  -L$(CERN_ROOT)/lib $(CERNLIBS) -L/usr/lib
+  OTHERLIBS =  -L/usr/lib
   FC  := gfortran
   F77 :=gfortran
 endif
@@ -147,5 +150,5 @@ mc_single_arm: $(my_objs) Makefile mc_single_arm.o
 	$(F77) -o $@ $(FFLAGS) mc_single_arm.o $(my_objs) $(OTHERLIBS)
 
 clean:
-	rm -f *.o $(H)*.o $(SH)*.o $(SHARE)*.o mc_single_arm
+	rm -f *.o $(H)*.o $(SH)*.o $(SHARE)*.o $(CH)*.o mc_single_arm
 

--- a/src/cern/abend.f
+++ b/src/cern/abend.f
@@ -1,0 +1,16 @@
+*
+* $Id: abend.F,v 1.1.1.1 1996/02/15 17:48:36 mclareni Exp $
+*
+* $Log: abend.F,v $
+* Revision 1.1.1.1  1996/02/15 17:48:36  mclareni
+* Kernlib
+*
+*
+#include "kernnumt/pilot.h"
+          SUBROUTINE ABEND
+#include "kernnumt/sysdat.inc"
+          IF(LGFILE .EQ. 0)  WRITE(*,1000)
+          IF(LGFILE .NE. 0)  WRITE(LGFILE,1000)
+          RETURN
+1000      FORMAT(31H ABEND ROUTINE HAS BEEN CALLED.)
+          END

--- a/src/cern/fint.f
+++ b/src/cern/fint.f
@@ -1,0 +1,84 @@
+*
+* $Id: fint.F,v 1.1.1.1 1996/02/15 17:48:36 mclareni Exp $
+*
+* $Log: fint.F,v $
+* Revision 1.1.1.1  1996/02/15 17:48:36  mclareni
+* Kernlib
+*
+*
+#include "kernnum/pilot.h"
+          FUNCTION FINT(NARG,ARG,NENT,ENT,TABLE)
+C
+C   INTERPOLATION ROUTINE. AUTHOR C. LETERTRE.
+C   MODIFIED BY B. SCHORR, 1.07.1982.
+C
+          INTEGER   NENT(9)
+          REAL*4      ARG(9),   ENT(9),   TABLE(9)
+          INTEGER   INDEX(32)
+          REAL      WEIGHT(32)
+          LOGICAL   MFLAG,    RFLAG
+          FINT  =  0.
+          IF(NARG .LT. 1  .OR.  NARG .GT. 5)  GOTO 300
+          LMAX      =  0
+          ISTEP     =  1
+          KNOTS     =  1
+          INDEX(1)  =  1
+          WEIGHT(1) =  1.
+          DO 100    N  =  1, NARG
+             X     =  ARG(N)
+             NDIM  =  NENT(N)
+             LOCA  =  LMAX
+             LMIN  =  LMAX + 1
+             LMAX  =  LMAX + NDIM
+             IF(NDIM .GT. 2)  GOTO 10
+             IF(NDIM .EQ. 1)  GOTO 100
+             H  =  X - ENT(LMIN)
+             IF(H .EQ. 0.)  GOTO 90
+             ISHIFT  =  ISTEP
+             IF(X-ENT(LMIN+1) .EQ. 0.)  GOTO 21
+             ISHIFT  =  0
+             ETA     =  H / (ENT(LMIN+1) - ENT(LMIN))
+             GOTO 30
+  10         LOCB  =  LMAX + 1
+  11         LOCC  =  (LOCA+LOCB) / 2
+             IF(X-ENT(LOCC))  12, 20, 13
+  12         LOCB  =  LOCC
+             GOTO 14
+  13         LOCA  =  LOCC
+  14         IF(LOCB-LOCA .GT. 1)  GOTO 11
+             LOCA    =  MIN0( MAX0(LOCA,LMIN), LMAX-1 )
+             ISHIFT  =  (LOCA - LMIN) * ISTEP
+             ETA     =  (X - ENT(LOCA)) / (ENT(LOCA+1) - ENT(LOCA))
+             GOTO 30
+  20         ISHIFT  =  (LOCC - LMIN) * ISTEP
+  21         DO 22  K  =  1, KNOTS
+                INDEX(K)  =  INDEX(K) + ISHIFT
+  22            CONTINUE
+             GOTO 90
+  30         DO 31  K  =  1, KNOTS
+                INDEX(K)         =  INDEX(K) + ISHIFT
+                INDEX(K+KNOTS)   =  INDEX(K) + ISTEP
+                WEIGHT(K+KNOTS)  =  WEIGHT(K) * ETA
+                WEIGHT(K)        =  WEIGHT(K) - WEIGHT(K+KNOTS)
+  31            CONTINUE
+             KNOTS  =  2*KNOTS
+  90         ISTEP  =  ISTEP * NDIM
+ 100         CONTINUE
+          DO 200    K  =  1, KNOTS
+             I  =  INDEX(K)
+             FINT  =  FINT + WEIGHT(K) * TABLE(I)
+ 200         CONTINUE
+          RETURN
+ 300      CALL KERMTR('E104.1',LGFILE,MFLAG,RFLAG)
+          IF(MFLAG) THEN
+             IF(LGFILE .EQ. 0) THEN
+                WRITE(*,1000) NARG
+             ELSE
+                WRITE(LGFILE,1000) NARG
+             ENDIF
+          ENDIF
+          IF(.NOT. RFLAG) CALL ABEND
+          RETURN
+1000      FORMAT( 7X, 24HFUNCTION FINT ... NARG =,I6,
+     +              17H NOT WITHIN RANGE)
+          END

--- a/src/cern/kerset.f
+++ b/src/cern/kerset.f
@@ -1,0 +1,91 @@
+*
+* $Id: kerset.F,v 1.1.1.1 1996/02/15 17:48:35 mclareni Exp $
+*
+* $Log: kerset.F,v $
+* Revision 1.1.1.1  1996/02/15 17:48:35  mclareni
+* Kernlib
+*
+*
+#include "kernnum/pilot.h"
+          SUBROUTINE KERSET(ERCODE,LGFILE,LIMITM,LIMITR)
+                    PARAMETER(KOUNTE  =  27)
+          CHARACTER*6         ERCODE,   CODE(KOUNTE)
+          LOGICAL             MFLAG,    RFLAG
+          INTEGER             KNTM(KOUNTE),       KNTR(KOUNTE)
+          DATA      LOGF      /  0  /
+          DATA      CODE(1), KNTM(1), KNTR(1)  / 'C204.1', 255, 255 /
+          DATA      CODE(2), KNTM(2), KNTR(2)  / 'C204.2', 255, 255 /
+          DATA      CODE(3), KNTM(3), KNTR(3)  / 'C204.3', 255, 255 /
+          DATA      CODE(4), KNTM(4), KNTR(4)  / 'C205.1', 255, 255 /
+          DATA      CODE(5), KNTM(5), KNTR(5)  / 'C205.2', 255, 255 /
+          DATA      CODE(6), KNTM(6), KNTR(6)  / 'C305.1', 255, 255 /
+          DATA      CODE(7), KNTM(7), KNTR(7)  / 'C308.1', 255, 255 /
+          DATA      CODE(8), KNTM(8), KNTR(8)  / 'C312.1', 255, 255 /
+          DATA      CODE(9), KNTM(9), KNTR(9)  / 'C313.1', 255, 255 /
+          DATA      CODE(10),KNTM(10),KNTR(10) / 'C336.1', 255, 255 /
+          DATA      CODE(11),KNTM(11),KNTR(11) / 'C337.1', 255, 255 /
+          DATA      CODE(12),KNTM(12),KNTR(12) / 'C341.1', 255, 255 /
+          DATA      CODE(13),KNTM(13),KNTR(13) / 'D103.1', 255, 255 /
+          DATA      CODE(14),KNTM(14),KNTR(14) / 'D106.1', 255, 255 /
+          DATA      CODE(15),KNTM(15),KNTR(15) / 'D209.1', 255, 255 /
+          DATA      CODE(16),KNTM(16),KNTR(16) / 'D509.1', 255, 255 /
+          DATA      CODE(17),KNTM(17),KNTR(17) / 'E100.1', 255, 255 /
+          DATA      CODE(18),KNTM(18),KNTR(18) / 'E104.1', 255, 255 /
+          DATA      CODE(19),KNTM(19),KNTR(19) / 'E105.1', 255, 255 /
+          DATA      CODE(20),KNTM(20),KNTR(20) / 'E208.1', 255, 255 /
+          DATA      CODE(21),KNTM(21),KNTR(21) / 'E208.2', 255, 255 /
+          DATA      CODE(22),KNTM(22),KNTR(22) / 'F010.1', 255,   0 /
+          DATA      CODE(23),KNTM(23),KNTR(23) / 'F011.1', 255,   0 /
+          DATA      CODE(24),KNTM(24),KNTR(24) / 'F012.1', 255,   0 /
+          DATA      CODE(25),KNTM(25),KNTR(25) / 'F406.1', 255,   0 /
+          DATA      CODE(26),KNTM(26),KNTR(26) / 'G100.1', 255, 255 /
+          DATA      CODE(27),KNTM(27),KNTR(27) / 'G100.2', 255, 255 /
+          LOGF  =  LGFILE
+             L  =  0
+          IF(ERCODE .NE. ' ')  THEN
+             DO 10  L = 1, 6
+                IF(ERCODE(1:L) .EQ. ERCODE)  GOTO 12
+  10            CONTINUE
+  12         CONTINUE
+          ENDIF
+          DO 14     I  =  1, KOUNTE
+             IF(L .EQ. 0)  GOTO 13
+             IF(CODE(I)(1:L) .NE. ERCODE(1:L))  GOTO 14
+  13         IF(LIMITM.GE.0) KNTM(I)  =  LIMITM
+             IF(LIMITR.GE.0) KNTR(I)  =  LIMITR
+  14         CONTINUE
+          RETURN
+          ENTRY KERMTR(ERCODE,LOG,MFLAG,RFLAG)
+          LOG  =  LOGF
+          DO 20     I  =  1, KOUNTE
+             IF(ERCODE .EQ. CODE(I))  GOTO 21
+  20         CONTINUE
+          WRITE(*,1000)  ERCODE
+          CALL ABEND
+          RETURN
+  21      RFLAG  =  KNTR(I) .GE. 1
+          IF(RFLAG  .AND.  (KNTR(I) .LT. 255))  KNTR(I)  =  KNTR(I) - 1
+          MFLAG  =  KNTM(I) .GE. 1
+          IF(MFLAG  .AND.  (KNTM(I) .LT. 255))  KNTM(I)  =  KNTM(I) - 1
+          IF(.NOT. RFLAG)  THEN
+             IF(LOGF .LT. 1)  THEN
+                WRITE(*,1001)  CODE(I)
+             ELSE
+                WRITE(LOGF,1001)  CODE(I)
+             ENDIF
+          ENDIF
+          IF(MFLAG .AND. RFLAG)  THEN
+             IF(LOGF .LT. 1)  THEN
+                WRITE(*,1002)  CODE(I)
+             ELSE
+                WRITE(LOGF,1002)  CODE(I)
+             ENDIF
+          ENDIF
+          RETURN
+1000      FORMAT(' KERNLIB LIBRARY ERROR. ' /
+     +           ' ERROR CODE ',A6,' NOT RECOGNIZED BY KERMTR',
+     +           ' ERROR MONITOR. RUN ABORTED.')
+1001      FORMAT(/' ***** RUN TERMINATED BY CERN LIBRARY ERROR ',
+     +           'CONDITION ',A6)
+1002      FORMAT(/' ***** CERN LIBRARY ERROR CONDITION ',A6)
+          END

--- a/src/cern/lfit.f
+++ b/src/cern/lfit.f
@@ -1,0 +1,61 @@
+*
+* $Id: lfit.F,v 1.1.1.1 1996/04/01 15:02:28 mclareni Exp $
+*
+* $Log: lfit.F,v $
+* Revision 1.1.1.1  1996/04/01 15:02:28  mclareni
+* Mathlib gen
+*
+*
+#include "gen/pilot.h"
+#if defined(CERNLIB_FORTRAN)||!defined(CERNLIB_CDC)
+      SUBROUTINE LFIT(X,Y,L,KEY,A,B,E)
+C
+C     TO FIT A STRAIGHT LINE    Y=A*X+B    TO L POINTS WITH ERROR E
+C     SEE MENZEL , FORMULAS OF PHYSICS P.116
+C     POINTS WITH Y=0 ARE IGNOERD IF KEY=0
+C     L IS NO. OF POINTS
+C
+      REAL*4 X,Y,A,B,E
+      DIMENSION X(1),Y(1)
+C
+C     CALCULATE SUMS
+      IF(L-2) 25,1,1
+    1 COUNT=0.0
+      SUMX=0.0
+      SUMY=0.0
+      SUMXY=0.0
+      SUMXX=0.0
+      SUMYY=0.0
+      DO 10 J=1,L
+      IF(Y(J).EQ.0..AND.KEY.EQ.0) GO TO 10
+      SUMX=SUMX+X(J)
+      SUMY=SUMY+Y(J)
+      COUNT=COUNT+1.0
+   10 CONTINUE
+      IF(COUNT.LE.1.) GO TO 25
+      YMED=SUMY/COUNT
+      XMED=SUMX/COUNT
+      DO 20 J=1,L
+      IF(Y(J).EQ.0..AND.KEY.EQ.0) GO TO 20
+      SCARTX=X(J)-XMED
+      SCARTY=Y(J)-YMED
+      SUMXY=SUMXY+SCARTX   *SCARTY
+      SUMXX=SUMXX+SCARTX   *SCARTX
+      SUMYY=SUMYY+SCARTY   *SCARTY
+   20 CONTINUE
+C
+C     FIT PARAMETERS
+      IF(SUMXX.EQ.0.) GO TO 25
+      A=SUMXY/SUMXX
+      B=YMED-A*XMED
+      IF(COUNT.LT.3.) GO TO 101
+      E=(SUMYY-SUMXY*A          )/(COUNT-2.0)
+      GO TO 100
+C
+C     ISUFFICIENT POINTS
+   25 A=0.0
+      B=0.0
+  101 E=0.0
+  100 RETURN
+      END
+#endif

--- a/src/cern/ranlux.f
+++ b/src/cern/ranlux.f
@@ -1,0 +1,312 @@
+#include "isajet/pilot.h"
+#if defined(CERNLIB_RANLUX)
+      SUBROUTINE RANLUX(RVEC,LENV)
+C         Subtract-and-borrow random number generator proposed by
+C         Marsaglia and Zaman, implemented by F. James with the name
+C         RCARRY in 1991, and later improved by Martin Luescher
+C         in 1993 to produce "Luxury Pseudorandom Numbers".
+C     Fortran 77 coded by F. James, 1993
+C
+C     Modified from 1999 CERN Program Library by F. Paige:
+C     CPP call removed (unused)
+C     Use ITLIS for output
+C
+C   LUXURY LEVELS.
+C   ------ ------      The available luxury levels are:
+C
+C  level 0  (p=24): equivalent to the original RCARRY of Marsaglia
+C           and Zaman, very long period, but fails many tests.
+C  level 1  (p=48): considerable improvement in quality over level 0,
+C           now passes the gap test, but still fails spectral test.
+C  level 2  (p=97): passes all known tests, but theoretically still
+C           defective.
+C  level 3  (p=223): DEFAULT VALUE.  Any theoretically possible
+C           correlations have very small chance of being observed.
+C  level 4  (p=389): highest possible luxury, all 24 bits chaotic.
+C
+C!!! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+C!!!  Calling sequences for RANLUX:                                  ++
+C!!!      CALL RANLUX (RVEC, LEN)   returns a vector RVEC of LEN     ++
+C!!!                   32-bit random floating point numbers between  ++
+C!!!                   zero (not included) and one (also not incl.). ++
+C!!!      CALL RLUXGO(LUX,INT,K1,K2) initializes the generator from  ++
+C!!!               one 32-bit integer INT and sets Luxury Level LUX  ++
+C!!!               which is integer between zero and MAXLEV, or if   ++
+C!!!               LUX .GT. 24, it sets p=LUX directly.  K1 and K2   ++
+C!!!               should be set to zero unless restarting at a break++ 
+C!!!               point given by output of RLUXAT (see RLUXAT).     ++
+C!!!      CALL RLUXAT(LUX,INT,K1,K2) gets the values of four integers++
+C!!!               which can be used to restart the RANLUX generator ++
+C!!!               at the current point by calling RLUXGO.  K1 and K2++
+C!!!               specify how many numbers were generated since the ++
+C!!!               initialization with LUX and INT.  The restarting  ++
+C!!!               skips over  K1+K2*E9   numbers, so it can be long.++
+C!!!   A more efficient but less convenient way of restarting is by: ++
+C!!!      CALL RLUXIN(ISVEC)    restarts the generator from vector   ++
+C!!!                   ISVEC of 25 32-bit integers (see RLUXUT)      ++
+C!!!      CALL RLUXUT(ISVEC)    outputs the current values of the 25 ++
+C!!!                 32-bit integer seeds, to be used for restarting ++
+C!!!      ISVEC must be dimensioned 25 in the calling program        ++
+C!!! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#include "isajet/itapes.inc"
+C
+      DIMENSION RVEC(LENV)
+      DIMENSION SEEDS(24), ISEEDS(24), ISDEXT(25)
+      PARAMETER (MAXLEV=4, LXDFLT=3)
+      DIMENSION NDSKIP(0:MAXLEV)
+      DIMENSION NEXT(24)
+      PARAMETER (TWOP12=4096., IGIGA=1000000000,JSDFLT=314159265)
+      PARAMETER (ITWO24=2**24, ICONS=2147483563)
+      SAVE NOTYET, I24, J24, CARRY, SEEDS, TWOM24, TWOM12, LUXLEV
+      SAVE NSKIP, NDSKIP, IN24, NEXT, KOUNT, MKOUNT, INSEED
+      INTEGER LUXLEV
+      LOGICAL NOTYET
+      DATA NOTYET, LUXLEV, IN24, KOUNT, MKOUNT /.TRUE., LXDFLT, 0,0,0/
+      DATA I24,J24,CARRY/24,10,0./
+C                               default
+C  Luxury Level   0     1     2   *3*    4
+      DATA NDSKIP/0,   24,   73,  199,  365 /
+Corresponds to p=24    48    97   223   389
+C     time factor 1     2     3     6    10   on slow workstation
+C                 1    1.5    2     3     5   on fast mainframe
+C
+C  NOTYET is .TRUE. if no initialization has been performed yet.
+C              Default Initialization by Multiplicative Congruential
+      IF (NOTYET) THEN
+         NOTYET = .FALSE.
+         JSEED = JSDFLT  
+         INSEED = JSEED
+         WRITE(ITLIS,'(A,I12)') ' RANLUX DEFAULT INITIALIZATION: ',JSEED
+         LUXLEV = LXDFLT
+         NSKIP = NDSKIP(LUXLEV)
+         LP = NSKIP + 24
+         IN24 = 0
+         KOUNT = 0
+         MKOUNT = 0
+         WRITE(ITLIS,'(A,I2,A,I4)') ' RANLUX DEFAULT LUXURY LEVEL =  ',
+     +        LUXLEV,'      p =',LP
+            TWOM24 = 1.
+         DO 25 I= 1, 24
+            TWOM24 = TWOM24 * 0.5
+         K = JSEED/53668
+         JSEED = 40014*(JSEED-K*53668) -K*12211
+         IF (JSEED .LT. 0)  JSEED = JSEED+ICONS
+         ISEEDS(I) = MOD(JSEED,ITWO24)
+   25    CONTINUE
+         TWOM12 = TWOM24 * 4096.
+         DO 50 I= 1,24
+         SEEDS(I) = REAL(ISEEDS(I))*TWOM24
+         NEXT(I) = I-1
+   50    CONTINUE
+         NEXT(1) = 24
+         I24 = 24
+         J24 = 10
+         CARRY = 0.
+         IF (SEEDS(24) .EQ. 0.) CARRY = TWOM24
+      ENDIF
+C
+C          The Generator proper: "Subtract-with-borrow",
+C          as proposed by Marsaglia and Zaman,
+C          Florida State University, March, 1989
+C
+      DO 100 IVEC= 1, LENV
+      UNI = SEEDS(J24) - SEEDS(I24) - CARRY 
+      IF (UNI .LT. 0.)  THEN
+         UNI = UNI + 1.0
+         CARRY = TWOM24
+      ELSE
+         CARRY = 0.
+      ENDIF
+      SEEDS(I24) = UNI
+      I24 = NEXT(I24)
+      J24 = NEXT(J24)
+      RVEC(IVEC) = UNI
+C  small numbers (with less than 12 "significant" bits) are "padded".
+      IF (UNI .LT. TWOM12)  THEN
+         RVEC(IVEC) = RVEC(IVEC) + TWOM24*SEEDS(J24)
+C        and zero is forbidden in case someone takes a logarithm
+         IF (RVEC(IVEC) .EQ. 0.)  RVEC(IVEC) = TWOM24*TWOM24
+      ENDIF
+C        Skipping to luxury.  As proposed by Martin Luscher.
+      IN24 = IN24 + 1
+      IF (IN24 .EQ. 24)  THEN
+         IN24 = 0
+         KOUNT = KOUNT + NSKIP
+         DO 90 ISK= 1, NSKIP
+         UNI = SEEDS(J24) - SEEDS(I24) - CARRY
+         IF (UNI .LT. 0.)  THEN
+            UNI = UNI + 1.0
+            CARRY = TWOM24
+         ELSE
+            CARRY = 0.
+         ENDIF
+         SEEDS(I24) = UNI
+         I24 = NEXT(I24)
+         J24 = NEXT(J24)
+   90    CONTINUE
+      ENDIF
+  100 CONTINUE
+      KOUNT = KOUNT + LENV
+      IF (KOUNT .GE. IGIGA)  THEN
+         MKOUNT = MKOUNT + 1
+         KOUNT = KOUNT - IGIGA
+      ENDIF
+      RETURN
+C
+C           Entry to input and float integer seeds from previous run
+      ENTRY RLUXIN(ISDEXT)
+         NOTYET = .FALSE.
+         TWOM24 = 1.
+         DO 195 I= 1, 24
+         NEXT(I) = I-1
+  195    TWOM24 = TWOM24 * 0.5
+         NEXT(1) = 24
+         TWOM12 = TWOM24 * 4096.
+      WRITE(ITLIS,'(A)') 
+     $' FULL INITIALIZATION OF RANLUX WITH 25 INTEGERS:'
+      WRITE(ITLIS,'(5X,5I12)') ISDEXT
+      DO 200 I= 1, 24
+      SEEDS(I) = REAL(ISDEXT(I))*TWOM24
+  200 CONTINUE
+      CARRY = 0.
+      IF (ISDEXT(25) .LT. 0)  CARRY = TWOM24
+      ISD = IABS(ISDEXT(25))
+      I24 = MOD(ISD,100)
+      ISD = ISD/100
+      J24 = MOD(ISD,100)
+      ISD = ISD/100
+      IN24 = MOD(ISD,100)
+      ISD = ISD/100
+      LUXLEV = ISD
+        IF (LUXLEV .LE. MAXLEV) THEN
+          NSKIP = NDSKIP(LUXLEV)
+          WRITE (ITLIS,'(A,I2)') 
+     $    ' RANLUX LUXURY LEVEL SET BY RLUXIN TO: ',
+     +                         LUXLEV
+        ELSE  IF (LUXLEV .GE. 24) THEN
+          NSKIP = LUXLEV - 24
+          WRITE (ITLIS,'(A,I5)') 
+     $    ' RANLUX P-VALUE SET BY RLUXIN TO:',LUXLEV
+        ELSE
+          NSKIP = NDSKIP(MAXLEV)
+          WRITE (ITLIS,'(A,I5)') 
+     $    ' RANLUX ILLEGAL LUXURY RLUXIN: ',LUXLEV
+          LUXLEV = MAXLEV
+        ENDIF
+      INSEED = -1
+      RETURN
+C
+C                    Entry to ouput seeds as integers
+      ENTRY RLUXUT(ISDEXT)
+      DO 300 I= 1, 24
+         ISDEXT(I) = INT(SEEDS(I)*TWOP12*TWOP12)
+  300 CONTINUE
+      ISDEXT(25) = I24 + 100*J24 + 10000*IN24 + 1000000*LUXLEV
+      IF (CARRY .GT. 0.)  ISDEXT(25) = -ISDEXT(25)
+      RETURN
+C
+C                    Entry to output the "convenient" restart point
+      ENTRY RLUXAT(LOUT,INOUT,K1,K2)
+      LOUT = LUXLEV
+      INOUT = INSEED
+      K1 = KOUNT
+      K2 = MKOUNT
+      RETURN
+C
+C                    Entry to initialize from one or three integers
+      ENTRY RLUXGO(LUX,INS,K1,K2)
+         IF (LUX .LT. 0) THEN
+            LUXLEV = LXDFLT
+         ELSE IF (LUX .LE. MAXLEV) THEN
+            LUXLEV = LUX
+         ELSE IF (LUX .LT. 24 .OR. LUX .GT. 2000) THEN
+            LUXLEV = MAXLEV
+            WRITE (ITLIS,'(A,I7)') ' RANLUX ILLEGAL LUXURY RLUXGO: ',LUX
+         ELSE
+            LUXLEV = LUX
+            DO 310 ILX= 0, MAXLEV
+              IF (LUX .EQ. NDSKIP(ILX)+24)  LUXLEV = ILX
+  310       CONTINUE
+         ENDIF
+      IF (LUXLEV .LE. MAXLEV)  THEN
+         NSKIP = NDSKIP(LUXLEV)
+         WRITE(ITLIS,'(A,I2,A,I4)') 
+     $   ' RANLUX LUXURY LEVEL SET BY RLUXGO :',
+     +        LUXLEV,'     P=', NSKIP+24
+      ELSE
+          NSKIP = LUXLEV - 24
+          WRITE (ITLIS,'(A,I5)') 
+     $    ' RANLUX P-VALUE SET BY RLUXGO TO:',LUXLEV
+      ENDIF
+      IN24 = 0
+      IF (INS .LT. 0)  WRITE (ITLIS,'(A)')   
+     +   ' Illegal initialization by RLUXGO, negative input seed'
+      IF (INS .GT. 0)  THEN
+        JSEED = INS
+        WRITE(ITLIS,'(A,3I12)') 
+     $  ' RANLUX INITIALIZED BY RLUXGO FROM SEEDS',
+     +      JSEED, K1,K2
+      ELSE
+        JSEED = JSDFLT
+        WRITE(6,'(A)')' RANLUX INITIALIZED BY RLUXGO FROM DEFAULT SEED'
+      ENDIF
+      INSEED = JSEED
+      NOTYET = .FALSE.
+      TWOM24 = 1.
+         DO 325 I= 1, 24
+           TWOM24 = TWOM24 * 0.5
+         K = JSEED/53668
+         JSEED = 40014*(JSEED-K*53668) -K*12211
+         IF (JSEED .LT. 0)  JSEED = JSEED+ICONS
+         ISEEDS(I) = MOD(JSEED,ITWO24)
+  325    CONTINUE
+      TWOM12 = TWOM24 * 4096.
+         DO 350 I= 1,24
+         SEEDS(I) = REAL(ISEEDS(I))*TWOM24
+         NEXT(I) = I-1
+  350    CONTINUE
+      NEXT(1) = 24
+      I24 = 24
+      J24 = 10
+      CARRY = 0.
+      IF (SEEDS(24) .EQ. 0.) CARRY = TWOM24
+C        If restarting at a break point, skip K1 + IGIGA*K2
+C        Note that this is the number of numbers delivered to
+C        the user PLUS the number skipped (if luxury .GT. 0).
+      KOUNT = K1
+      MKOUNT = K2
+      IF (K1+K2 .NE. 0)  THEN
+        DO 500 IOUTER= 1, K2+1
+          INNER = IGIGA
+          IF (IOUTER .EQ. K2+1)  INNER = K1
+          DO 450 ISK= 1, INNER
+            UNI = SEEDS(J24) - SEEDS(I24) - CARRY 
+            IF (UNI .LT. 0.)  THEN
+               UNI = UNI + 1.0
+               CARRY = TWOM24
+            ELSE
+               CARRY = 0.
+            ENDIF
+            SEEDS(I24) = UNI
+            I24 = NEXT(I24)
+            J24 = NEXT(J24)
+  450     CONTINUE
+  500   CONTINUE
+C         Get the right value of IN24 by direct calculation
+        IN24 = MOD(KOUNT, NSKIP+24)
+        IF (MKOUNT .GT. 0)  THEN
+           IZIP = MOD(IGIGA, NSKIP+24)
+           IZIP2 = MKOUNT*IZIP + IN24
+           IN24 = MOD(IZIP2, NSKIP+24)
+        ENDIF
+C       Now IN24 had better be between zero and 23 inclusive
+        IF (IN24 .GT. 23) THEN
+           WRITE (ITLIS,'(A/A,3I11,A,I5)')  
+     +    '  Error in RESTARTING with RLUXGO:','  The values', INS,
+     +     K1, K2, ' cannot occur at luxury level', LUXLEV
+           IN24 = 0
+        ENDIF
+      ENDIF
+      RETURN
+      END
+#endif

--- a/src/hbook.inc
+++ b/src/hbook.inc
@@ -1,0 +1,5 @@
+C Ntuple ID stuff
+
+	integer*4       NtupleIO,NtupleSize,SpecNtupleIO,SpecNtupleSize
+  
+	common		NtupleIO,NtupleSize,SpecNtupleIO,SpecNtupleSize

--- a/src/hms_hbook_init.f
+++ b/src/hms_hbook_init.f
@@ -1,17 +1,12 @@
       subroutine hms_hbook_init(filename,spec_ntuple)
-C Initialize ntuples differently based on which spectrometer we
+C Initialize output names differently based on which spectrometer we
 C are using
 C
-C HBOOK/NTUPLE common block and parameters.
+      implicit none
+      include 'hbook.inc'
       character*80 filename
-      logical*4 spec_ntuple
-      integer*4	pawc_size
-      parameter	(pawc_size = 10000000)
-      common		/pawc/ hbdata(pawc_size)
-      integer*4	hbdata
-      common /QUEST/ iquest(100)
-      integer*4 iquest
-      character*8	hut_nt_names(23)/
+      logical spec_ntuple
+      character*16	hut_nt_names(23)/
      >     'hsxfp', 'hsyfp', 'hsxpfp', 'hsypfp',
      >     'hsxtari','hsytari','hsxptari','hsyptari',
      >     'hsztari','hsdeltai','hsytar','hsxptar',
@@ -19,39 +14,17 @@ C HBOOK/NTUPLE common block and parameters.
      >     'xsnum','ysnum','xsieve','ysieve','stop_id',
      >     'hsvxi','hsvyi' /
 
-      call hlimit(pawc_size)
+      integer*4 i
 
-c By Jixie: to create a large ntuple, we need to do the following 4 things:
-c  1) CALL hlimit(pawc_size) with a big argument (set 'pawc_size' to a big value). 
-c  2) set 'iquest(10)' to a big number, this value means the maximum records.
-c     Important note: It is very important to initialise IQUEST(10) just before
-c     the call to HROPEN. The QUEST common block is used a lot in the whole CERNLIB,
-c     and in particular in HBOOK, so if the value of IQUEST(10) is defined too far
-c     from the call to HROPEN, very likely it will not have the expected value when
-c     needed. 
-c  3) CALL HROPEN with a large value of LRECL (ex LRECL=4096 instead of 1024)
-c     and you can get files 4 times bigger. This value means the maximum words
-c     in one record.
-c  4) CALL HROPEN with the option QE (E for "Extended"). This option allows to
-c     have up to 2**32 records in an HBOOK file.
-c  By default, no nutuple will be larger than 2G Bytes. Other place need to be
-c  changed if you want that happen.
-c  Check https://userweb.jlab.org/~brads/Manuals/pawfaq/ for details
-!  also see for example
-!   http://wwwasd.web.cern.ch/wwwasd/cgi-bin/listpawfaqs.pl/7
+      NtupleIO=30
+      NtupleSize=23
 
-      iquest(10) = 512000
-      call hropen(30,'HUT',filename,'NQE',4096,i) !CERNLIB
- 
-      if (i.ne.0) then
-         write(*,*),'HROPEN error: istat = ',i
-         stop
-      endif
+      open(NtupleIO,file=filename,form="unformatted",access="sequential")
 
-      call hbookn(1,'HUT NTUPLE',23,'HUT',10000,hut_nt_names)
-c      if (spec_ntuple) then
-c         call hbookn(1412,'SPEC NTU',58,'HUT',10000,spec_nt_names)
-c      endif
+      write(NtupleIO) NtupleSize
+      do i=1,NtupleSize
+         write(NtupleIO) hut_nt_names(i)
+      enddo
 
       return
       end

--- a/util/ntuple/Makefile
+++ b/util/ntuple/Makefile
@@ -1,0 +1,56 @@
+## This makefile must be executed with gmake (gnu make).
+
+## This tells make not to delete these target files on error/interrupt (see man page)
+.PRECIOUS: *.o 
+RM        = rm -f 
+SHELL     = /bin/sh
+
+OBJ	= make_ntuple.o
+ 
+my_objs	=  $(OBJ)
+
+my_deps = $(my_objs:.o=.d)
+
+MYOS := $(subst -,,$(shell uname))
+#CERNLIBS = -lgeant$(GEANTVER) -lpawlib -lgraflib -lgrafX11 -lpacklib -lmathlib
+CERNLIBS = -Wl,-static -lgeant$(GEANTVER) -lpawlib -lgraflib -lgrafX11 -lpacklib -lkernlib -lmathlib -Wl,-dy
+
+#
+CERN_ROOT=/cvmfs/oasis.opensciencegrid.org/jlab/scicomp/sw/el9/cernlib/2023
+#For use with gfortran compiler
+# -fno-automatic - all program storage treated as static
+ifeq ($(MYOS),Linux)
+  FFLAGSA=-O -w -ffixed-line-length-132 -ff2c -fno-automatic -fdefault-real-8
+  INCLUDES=-I.
+  FFLAGS= $(INCLUDES) $(FFLAGSA)
+  FFLAG1=$(FFLAGS) -c
+  OTHERLIBS = -L$(CERN_ROOT)/lib $(CERNLIBS) -L/usr/lib64 
+# 64 vs 32 bit
+#        -L$(CERN_ROOT)/lib $(CERNLIBS) -L/usr/lib
+  FC  := gfortran
+  F77 := gfortran
+endif
+
+%.o: %.f
+	$(F77) $(FFLAGS) -c $< -o $@
+
+DEPEND_RULE = ( cat $< |  sed -n -e \
+	"s|^[ 	]*[Ii][Nn][Cc][Ll][Uu][Dd][Ee][ 	]*['\"]|$@: $(@D)/|p" | \
+	sed -e "s|['\"].*$$||" | \
+	sed -e 's|.d:|.o:|') > $@
+
+%.d: %.f
+	$(DEPEND_RULE)
+
+none: make_ntuple $(my_deps)
+
+all: make_ntuple  $(my_deps)
+
+include $(my_deps)
+
+make_ntuple: $(my_objs) Makefile
+	$(F77) $(OSF_SHARED) -o $@ $(FFLAGS) $(my_objs) $(OTHERLIBS)
+
+clean:
+	$(RM) *.[od] make_ntuple
+

--- a/util/ntuple/Makefile.rhel7
+++ b/util/ntuple/Makefile.rhel7
@@ -1,0 +1,55 @@
+## This makefile must be executed with gmake (gnu make).
+
+## This tells make not to delete these target files on error/interrupt (see man page)
+.PRECIOUS: *.o 
+RM        = rm -f 
+SHELL     = /bin/sh
+
+OBJ	= make_ntuple.o
+ 
+my_objs	=  $(OBJ)
+
+my_deps = $(my_objs:.o=.d)
+
+MYOS := $(subst -,,$(shell uname))
+#CERNLIBS = -lgeant$(GEANTVER) -lpawlib -lgraflib -lgrafX11 -lpacklib -lmathlib
+CERNLIBS = -Wl,-static -lgeant$(GEANTVER) -lpawlib -lgraflib -lgrafX11 -lpacklib -lkernlib -lmathlib -Wl,-dy
+
+
+#For use with gfortran compiler
+# -fno-automatic - all program storage treated as static
+ifeq ($(MYOS),Linux)
+  FFLAGSA=-O -w -ffixed-line-length-132 -ff2c -fno-automatic -fdefault-real-8
+  INCLUDES=-I.
+  FFLAGS= $(INCLUDES) $(FFLAGSA)
+  FFLAG1=$(FFLAGS) -c
+  OTHERLIBS = -L$(CERN_ROOT)/lib $(CERNLIBS) -L/usr/lib64 
+# 64 vs 32 bit
+#        -L$(CERN_ROOT)/lib $(CERNLIBS) -L/usr/lib
+  FC  := gfortran
+  F77 := gfortran
+endif
+
+%.o: %.f
+	$(F77) $(FFLAGS) -c $< -o $@
+
+DEPEND_RULE = ( cat $< |  sed -n -e \
+	"s|^[ 	]*[Ii][Nn][Cc][Ll][Uu][Dd][Ee][ 	]*['\"]|$@: $(@D)/|p" | \
+	sed -e "s|['\"].*$$||" | \
+	sed -e 's|.d:|.o:|') > $@
+
+%.d: %.f
+	$(DEPEND_RULE)
+
+none: make_ntuple $(my_deps)
+
+all: make_ntuple  $(my_deps)
+
+include $(my_deps)
+
+make_ntuple: $(my_objs) Makefile
+	$(F77) $(OSF_SHARED) -o $@ $(FFLAGS) $(my_objs) $(OTHERLIBS)
+
+clean:
+	$(RM) *.[od] make_ntuple
+

--- a/util/ntuple/Makefile.rhel9
+++ b/util/ntuple/Makefile.rhel9
@@ -1,0 +1,56 @@
+## This makefile must be executed with gmake (gnu make).
+
+## This tells make not to delete these target files on error/interrupt (see man page)
+.PRECIOUS: *.o 
+RM        = rm -f 
+SHELL     = /bin/sh
+
+OBJ	= make_ntuple.o
+ 
+my_objs	=  $(OBJ)
+
+my_deps = $(my_objs:.o=.d)
+
+MYOS := $(subst -,,$(shell uname))
+#CERNLIBS = -lgeant$(GEANTVER) -lpawlib -lgraflib -lgrafX11 -lpacklib -lmathlib
+CERNLIBS = -Wl,-static -lgeant$(GEANTVER) -lpawlib -lgraflib -lgrafX11 -lpacklib -lkernlib -lmathlib -Wl,-dy
+
+#
+CERN_ROOT=/cvmfs/oasis.opensciencegrid.org/jlab/scicomp/sw/el9/cernlib/2023
+#For use with gfortran compiler
+# -fno-automatic - all program storage treated as static
+ifeq ($(MYOS),Linux)
+  FFLAGSA=-O -w -ffixed-line-length-132 -ff2c -fno-automatic -fdefault-real-8
+  INCLUDES=-I.
+  FFLAGS= $(INCLUDES) $(FFLAGSA)
+  FFLAG1=$(FFLAGS) -c
+  OTHERLIBS = -L$(CERN_ROOT)/lib $(CERNLIBS) -L/usr/lib64 
+# 64 vs 32 bit
+#        -L$(CERN_ROOT)/lib $(CERNLIBS) -L/usr/lib
+  FC  := gfortran
+  F77 := gfortran
+endif
+
+%.o: %.f
+	$(F77) $(FFLAGS) -c $< -o $@
+
+DEPEND_RULE = ( cat $< |  sed -n -e \
+	"s|^[ 	]*[Ii][Nn][Cc][Ll][Uu][Dd][Ee][ 	]*['\"]|$@: $(@D)/|p" | \
+	sed -e "s|['\"].*$$||" | \
+	sed -e 's|.d:|.o:|') > $@
+
+%.d: %.f
+	$(DEPEND_RULE)
+
+none: make_ntuple $(my_deps)
+
+all: make_ntuple  $(my_deps)
+
+include $(my_deps)
+
+make_ntuple: $(my_objs) Makefile
+	$(F77) $(OSF_SHARED) -o $@ $(FFLAGS) $(my_objs) $(OTHERLIBS)
+
+clean:
+	$(RM) *.[od] make_ntuple
+

--- a/util/ntuple/make_ntuple.f
+++ b/util/ntuple/make_ntuple.f
@@ -1,0 +1,103 @@
+      program make_ntuple
+C     Program to convert simc .bin file to ntupl
+      implicit none
+
+*-sizes of CERNLIB working space
+
+      integer HbookSize,HigzSize,KuipSize,PawSize
+      parameter (HbookSize = 100000)
+      parameter (HigzSize =  50000)
+      parameter (KuipSize =  75000)
+      parameter (PawSize = HigzSize+KuipSize+HbookSize+100000)
+
+*-CERNLIB working space
+
+      integer CernMemory(PawSize)
+      common /PAWC/ CernMemory  !special nonstandard name!
+
+C Ntuple ID stuff
+
+      integer*4	defaultID
+      parameter     	(defaultID = 666)
+      character*132 	NtupleDirectory
+      character*16    NtupleName
+      integer*4       NtupleID,NtupleIO,NtupleSize
+      integer*4 recl,status, cycle, bank
+
+      character*16 NtupleTag(80)
+      character*80 rawname,filename,ntfilename,directory
+      character*16 title
+      integer io,i,j,check
+      integer chanout
+      integer nev
+      real*8 ntup(80)
+      real*4 ntup_out(80)
+
+      parameter(nev=10000000)
+
+      io=10
+      chanout=2
+      NtupleID=defaultID
+      recl=4096
+      bank=8000
+
+      NtupleName='MCNtuple'
+      title='SIMTUPLE'
+
+      call hlimit(PawSize)
+c input filename
+      write(6,*) 'Enter filename to convert (without .bin extension)'
+      read(5,*) rawname
+      i=index(rawname,' ')
+      filename='../../worksim/'//rawname(1:i-1)//'.bin'
+      write(6,*) 'opening file: ',filename
+      open(io,file=filename,form="unformatted",access="sequential")
+
+c output filename
+      ntfilename='../../worksim/'//rawname(1:i-1)//'.rzdat'
+      call HCDIR(directory,'R')
+      call HROPEN(chanout,NtupleName,ntfilename,'N',recl,status)
+
+	if (status.ne.0)then
+	  write(6,*) 'HROPEN error: istat=',status
+	  stop
+	endif
+
+
+      read(io) NtupleSize
+      write(6,*) 'Variables in output file: ',NtupleSize
+      do i=1,NtupleSize
+         read(io) NtupleTag(i)
+         write(6,*) NtupleTag(i)
+      enddo
+
+      call HBOOKN(NtupleID,title,NtupleSize,NtupleName,bank,NtupleTag) !create Ntuple
+      
+      call HCDIR(NtupleDirectory,'R') !record Ntuple directory
+
+      call HCDIR(directory,' ') !reset CERNLIB directory
+
+
+c now loop over events     
+      do j=1,nev
+         do i=1,NtupleSize
+            read(io,iostat=check) ntup(i)
+            if (check.lt.0) then
+               write(6,*) 'end of file'
+               write(6,*) 'processed ',j, 'events'
+               cycle=0
+               call HCDIR(NtupleDirectory,' ')
+               call HROUT(NtupleID,cycle,' ') !flush CERNLIB buffers
+               call HREND(NtupleName) !CERNLIB close file
+               write(6,*)'Closing file:',filename(1:60)
+               close(chanout)
+               stop
+            endif
+            ntup_out(i)=ntup(i)
+         enddo ! loop over ntuple variables
+         call HFN(NtupleID,ntup_out)         
+      enddo ! loop over events
+
+      end
+
+

--- a/util/root_tree/Makefile
+++ b/util/root_tree/Makefile
@@ -1,0 +1,51 @@
+## This makefile must be executed with gmake (gnu make).
+
+## This tells make not to delete these target files on error/interrupt (see man page)
+.PRECIOUS: *.o 
+RM        = rm -f 
+SHELL     = /bin/sh
+
+OBJ	= make_root_tree.o
+ 
+my_objs	=  $(OBJ)
+
+my_deps = $(my_objs:.o=.d)
+
+MYOS := $(subst -,,$(shell uname))
+
+#For use with gfortran compiler
+# -fno-automatic - all program storage treated as static
+ifeq ($(MYOS),Linux)
+  FFLAGSA=-
+  INCLUDES=
+  FFLAGS = -O3 -fno-automatic
+  OTHERLIBS = 
+  FC  := gfortran
+  F77 := gfortran
+endif
+
+ROOTSYS=/cvmfs/oasis.opensciencegrid.org/jlab/scicomp/sw/el9/root/6.30.04-gcc11.4.0
+CXX=g++
+CXXFLAGS0 = -O3 -std=c++17
+CXXFLAGS=$(CXXFLAGS0) $(DROOT)
+ROOTDIR=$(ROOTSYS)
+DMYROOT= -DMYROOT
+ROOTLIBS     := $(shell $(ROOTDIR)/bin/root-config --prefix=$(ROOTDIR)  --libs)
+ROOTINCLUDE  := -I $(shell $(ROOTDIR)/bin/root-config --prefix=$(ROOTDIR) --incdir)
+
+none: make_root_tree
+
+all: make_root_tree
+
+make_root_tree: $(my_objs) froot.co
+	$(F77) $(LDFLAGS) -o make_root_tree $(my_objs) $(OTHERLIBS) froot.co $(ROOTLIBS) -lImt -lvdt -ltbb $(OTHERLIBS) $(CERNLIBS) -L/usr/lib64 -lstdc++
+
+%.o: %.f
+	$(FC) -c $(FFLAGS) $<
+
+%.co: %.c
+	$(CXX) -c $(CXXFLAGS) $(DMYROOT) $(ROOTINCLUDE) -o $@ $<
+
+clean:
+	$(RM) *.o *.co make_root_tree
+

--- a/util/root_tree/Makefile.rhel7
+++ b/util/root_tree/Makefile.rhel7
@@ -1,0 +1,50 @@
+## This makefile must be executed with gmake (gnu make).
+
+## This tells make not to delete these target files on error/interrupt (see man page)
+.PRECIOUS: *.o 
+RM        = rm -f 
+SHELL     = /bin/sh
+
+OBJ	= make_root_tree.o
+ 
+my_objs	=  $(OBJ)
+
+my_deps = $(my_objs:.o=.d)
+
+MYOS := $(subst -,,$(shell uname))
+
+#For use with gfortran compiler
+# -fno-automatic - all program storage treated as static
+ifeq ($(MYOS),Linux)
+  FFLAGSA=-
+  INCLUDES=
+  FFLAGS = -O3 -fno-automatic
+  OTHERLIBS = 
+  FC  := gfortran
+  F77 := gfortran
+endif
+
+CXX=g++
+CXXFLAGS0 = -O3 -std=c++11
+CXXFLAGS=$(CXXFLAGS0) $(DROOT)
+ROOTDIR=$(ROOTSYS)
+DMYROOT= -DMYROOT
+ROOTLIBS     := $(shell $(ROOTDIR)/bin/root-config --prefix=$(ROOTDIR)  --libs)
+ROOTINCLUDE  := -I $(shell $(ROOTDIR)/bin/root-config --prefix=$(ROOTDIR) --incdir)
+
+none: make_root_tree
+
+all: make_root_tree
+
+make_root_tree: $(my_objs) froot.co
+	$(F77) $(LDFLAGS) -o make_root_tree $(my_objs) $(OTHERLIBS) froot.co $(ROOTLIBS) -lImt -lvdt -ltbb $(OTHERLIBS) $(CERNLIBS) -L/usr/lib64 -lstdc++
+
+%.o: %.f
+	$(FC) -c $(FFLAGS) $<
+
+%.co: %.c
+	$(CXX) -c $(CXXFLAGS) $(DMYROOT) $(ROOTINCLUDE) -o $@ $<
+
+clean:
+	$(RM) *.o *.co make_root_tree
+

--- a/util/root_tree/Makefile.rhel9
+++ b/util/root_tree/Makefile.rhel9
@@ -1,0 +1,51 @@
+## This makefile must be executed with gmake (gnu make).
+
+## This tells make not to delete these target files on error/interrupt (see man page)
+.PRECIOUS: *.o 
+RM        = rm -f 
+SHELL     = /bin/sh
+
+OBJ	= make_root_tree.o
+ 
+my_objs	=  $(OBJ)
+
+my_deps = $(my_objs:.o=.d)
+
+MYOS := $(subst -,,$(shell uname))
+
+#For use with gfortran compiler
+# -fno-automatic - all program storage treated as static
+ifeq ($(MYOS),Linux)
+  FFLAGSA=-
+  INCLUDES=
+  FFLAGS = -O3 -fno-automatic
+  OTHERLIBS = 
+  FC  := gfortran
+  F77 := gfortran
+endif
+
+ROOTSYS=/cvmfs/oasis.opensciencegrid.org/jlab/scicomp/sw/el9/root/6.30.04-gcc11.4.0
+CXX=g++
+CXXFLAGS0 = -O3 -std=c++17
+CXXFLAGS=$(CXXFLAGS0) $(DROOT)
+ROOTDIR=$(ROOTSYS)
+DMYROOT= -DMYROOT
+ROOTLIBS     := $(shell $(ROOTDIR)/bin/root-config --prefix=$(ROOTDIR)  --libs)
+ROOTINCLUDE  := -I $(shell $(ROOTDIR)/bin/root-config --prefix=$(ROOTDIR) --incdir)
+
+none: make_root_tree
+
+all: make_root_tree
+
+make_root_tree: $(my_objs) froot.co
+	$(F77) $(LDFLAGS) -o make_root_tree $(my_objs) $(OTHERLIBS) froot.co $(ROOTLIBS) -lImt -lvdt -ltbb $(OTHERLIBS) $(CERNLIBS) -L/usr/lib64 -lstdc++
+
+%.o: %.f
+	$(FC) -c $(FFLAGS) $<
+
+%.co: %.c
+	$(CXX) -c $(CXXFLAGS) $(DMYROOT) $(ROOTINCLUDE) -o $@ $<
+
+clean:
+	$(RM) *.o *.co make_root_tree
+

--- a/util/root_tree/froot.c
+++ b/util/root_tree/froot.c
@@ -1,0 +1,214 @@
+//#########################################################################
+//#                                                                       #
+//#                               FROOT.C                                 #
+//#                         Version June 2, 2008                          #
+//#                                                                       #
+//#########################################################################
+//#                                                                       #
+//# A simple interface to write numerical output from a standalone        #
+//# Fortran or C program into a ROOT ntuple and perform various           #
+//# manipulations on the output                                           #
+//#                                                                       #
+//#########################################################################
+//# Send comments to Pavel Nadolsky (nadolsky@pa.msu.edu)
+
+
+using namespace std;
+
+// These are the C functions accessible from Fortran. They must be 
+// described as 'extern "C"'
+
+extern "C" {
+  void initrootnt_(const char *title, const char *access, int ltitle, int laccess);
+  void reinitrootnt_(const char *access, int laccess);
+  void addntbranch_(float *element, const char *chtag, int ltag);
+  void fillntbranch_(const char *chtag, int ltag);
+  int getnumbranches_();
+  void rootntoutp_();
+  void printnt_();
+  void teststr_(const char *str, int lstr);
+
+}//extern "C"
+
+//////////////////////////////////////////////////////////////////////////
+// To link to the ROOT libraries, compile with a preprocessor option MYROOT
+// (-DMYROOT) specified in Makefile. If MYROOT is not defined, the code 
+// will be linked to dummy functions defined below
+
+#ifdef MYROOT
+
+#include <iostream>
+#include <fstream>
+#include <cstring>
+
+#include "TApplication.h"
+#include "TCanvas.h"
+#include "TFile.h"
+#include "TH1F.h"
+#include "TNtuple.h"
+
+
+//Pointers to the ROOT application for writing the ntuple, 
+//file with the ntuple, and the ntuple itself
+TApplication* app;
+TFile *outfile;   
+TTree *nt;
+
+//=========================================================== String routines
+char* strtoupper(char *str)
+  /* Converts a string str of the length strlen to uppercase letters */
+{ int m=0;
+  do
+    str[m] = toupper(str[m]);
+  while (str[m++]);
+  return &(str[0]);
+}
+
+
+
+//--------------------------------------------------------------------------
+char *truestr(const char *str, int len)
+     // Converts a Fortran character string str of length len into a properly
+     // formed C character string with '\0' at the end; trims blank spaces
+     // at the end of the string
+{
+ int tlen=0;
+ char tem;
+/*Counts non-blank charachters in a string str until a first blank character
+  or the end of the string is met*/
+
+ while (str[tlen] !=' ' && (tlen < len ) && (tem=str[tlen++],tem)) ;
+
+
+ char *tstr = new char[tlen+1];
+ strncpy(tstr,str,tlen);
+ tstr[tlen]='\0';
+
+ return tstr;
+}//truestr->
+
+
+void teststr_(const char *str,int lstr)
+{
+  cout << "In C:"<<truestr(str,lstr) <<"==========="<<endl;
+  return;
+}
+
+
+
+//------------------------------------------------------------------------
+
+void initrootnt_(const char *title, const char *access, int ltitle, int laccess)
+//Initialize the ROOT file for a given access mode 
+//Inputs: title -- the name of the file (e.g., 'resbos.root')
+//       access -- a string specifying the type of the access
+//       (equivalent to the string 'option' in the TFile constructor)
+//If access = 'NEW' or 'CREATE'   create a new file and open it 
+//                           for writing. If the file already exists 
+//                           the file is not opened.
+              //           = 'RECREATE'      create a new file. If the file already
+//                             exists, it will be overwritten.
+//           = 'UPDATE'        open an existing file for writing.
+//                             If no file exists, it is created.
+//           = 'READ'          open an existing file for reading (default).
+{
+  char *appName="FROOT.C";
+  int apprgc=1; 
+  char *appargv[]={appName};
+  app=new TApplication("App", &apprgc, appargv);
+
+  outfile = new TFile(truestr(title,ltitle),strtoupper(truestr(access,laccess)));
+
+  nt = (TTree*)outfile->Get("h10");
+  if (nt == 0x0 ) 
+    nt=new TTree("h10","h10");
+    
+  return;
+} //initrootnt_ ->
+
+//------------------------------------------------------------------------
+
+void reinitrootnt_(const char *access, int laccess)
+//Re-initialize the ROOT ntuple using a different access mode
+//This instruction is used to change the access mode to the ntuple before
+// it was closed by calling rootntoutp_(). See the example of the call of
+// reinitrootnt_ in taste_froot.f. The access modes are described in
+// the header of the subroutine initrootnt_(). 
+{
+
+  outfile->ReOpen(strtoupper(truestr(access,laccess)));
+    
+  nt = (TNtuple*)outfile->Get("h10");  
+
+  if (nt == 0x0) 
+    {
+      cout << "STOP in reinitrootnt_: error in opening the ntuple" << endl;
+      exit(10);
+    }
+
+  return;
+} //reinitrootnt_ ->
+
+
+//------------------------------------------------------------------------
+  void addntbranch_(float *element, const char *chtag, int ltag)
+    //Add an ntuple branch pointing at a Fortran variable element
+{
+  nt->Branch(truestr(chtag,ltag),element, truestr(chtag,ltag));
+
+  return;
+  }//addntbranch_ ->
+
+
+//------------------------------------------------------------------------
+void fillntbranch_(const char *chtag, int ltag)
+ //Fill the variable into the branch with the name chtag, or all branches
+ //if chtag='all'
+{
+  if (strcmp(truestr(chtag,ltag),"all") == 0)
+      nt->Fill();
+  else
+     (nt->GetBranch(truestr(chtag,ltag)))->Fill();
+
+  return;
+}//fillntbranch_ ->
+
+//------------------------------------------------------------------------
+void rootntoutp_()
+  //Close the ntuple file
+{
+  nt->Write("",TObject::kOverwrite);
+  outfile->Close();
+  return;
+}//rootntoutp_ ->
+
+//------------------------------------------------------------------------
+int getnumbranches_()
+//return the number of the branches in the ROOT ntuple
+{
+  return nt->GetNbranches();
+}//getnumbranches_
+
+//------------------------------------------------------------------------
+void printnt_()
+//Print the list of branches in the ntuple
+{
+  nt->Print();
+}//print_
+
+
+
+//------------------------------------------------------------------------
+
+#else //MYROOT is not defined; link to dummy functions instead of the actual ROOT functions
+//////////////////////////////////////////////////////////////////////////
+ void initrootnt_(const char *title, const char *access, int ltitle, int laccess){return;}
+ void reinitrootnt_(const char *access, int laccess){return;}
+ void addntbranch_(float *element, const char *chtag, int ltag){return;}
+ void fillntbranch_(const char *chtag, int ltag){return;}
+ int getnumbranches_(){return;}
+ void printnt_(){return;}
+ void rootntoutp_(){return;}
+
+#endif //MYROOT
+

--- a/util/root_tree/make_root_tree.f
+++ b/util/root_tree/make_root_tree.f
@@ -1,0 +1,60 @@
+      program make_root_tree
+C     Program to convert simc .bin file to root tree
+      implicit none
+
+      character*80 rawname,filename,treefilename
+      character*16 NtupleTag(80),varname
+      
+
+      integer i,j,nev,check
+      integer*4 io
+      integer*4 NtupleSize
+      integer GetNumBranches
+      external GetNumBranches
+
+      real*8 ntup(80)
+      real*4 ntup_out(80)
+
+      parameter(nev=10000000)
+      io=99
+
+c input filename
+      write(6,*) 'Enter filename to convert (without .bin extesntion)'
+      read(5,*) rawname
+      i=index(rawname,' ')
+      filename='../../worksim/'//rawname(1:i-1)//'.bin'
+      write(6,*) 'opening file: ',filename
+      open(io,file=filename,form="unformatted",access="sequential")
+
+c output filename
+      treefilename='../../worksim/'//rawname(1:i-1)//'.root'
+      
+      read(io) NtupleSize
+      call InitRootNT(treefilename,'RECREATE');
+
+      write(6,*) 'Variables in output file:'
+      do i=1,NtupleSize
+         read(io) NtupleTag(i)
+         call AddNtBranch(ntup_out(i),NtupleTag(i))
+      enddo
+
+c now loop over events     
+      do j=1,nev
+         do i=1,NtupleSize
+            read(io,iostat=check) ntup(i)
+            if (check.lt.0) then
+               call PrintNT()
+               call RootNTOutp();
+               stop
+            endif
+            ntup_out(i)=ntup(i)
+         enddo ! loop over ntuple variables
+         call FillNTBranch('all')
+      enddo ! loop over events
+
+      call PrintNT()
+      call RootNTOutp();
+
+      end
+
+


### PR DESCRIPTION
Removed cernlib library dependencies for easier rhel9/alma9 compatibility.  Separate programs in "util" directory can be used to make root trees or ntuples.