### PR TITLE
Add container runner and publish containers based on tags

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+mc-data
+outfiles
+runout
+worksim
+src/*.o
+src/*/*.o
+src/mc_single_arm
+util/root_tree/*.o
+util/root_tree/*.co
+util/root_tree/make_root_tree
+util/ntuple/*.o
+util/ntuple/*.co
+util/ntuple/make_ntuple

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,107 @@
+name: container
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "*"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build test image
+        run: docker build -f Containerfile -t mc-single-arm:test .
+
+      - name: Check runner help
+        run: docker run --rm mc-single-arm:test mc-single-arm-run --help
+
+      - name: Check description output
+        run: |
+          docker run --rm mc-single-arm:test mc-single-arm-api describe --format text
+          docker run --rm mc-single-arm:test mc-single-arm-api describe --format json
+
+      - name: Run container smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          DATA_ROOT="$(mktemp -d)"
+          INPUT_ROOT="$(mktemp -d)"
+
+          docker run --rm mc-single-arm:test \
+            cat /opt/mc-single-arm/share/infiles/shms_20deg_3gev_10cmtarg_cryo17.inp \
+            > "$INPUT_ROOT/smoke.inp"
+
+          python3 - "$INPUT_ROOT/smoke.inp" <<'PY'
+          import pathlib
+          import sys
+
+          path = pathlib.Path(sys.argv[1])
+          lines = path.read_text().splitlines()
+          for index, line in enumerate(lines):
+              stripped = line.strip()
+              if stripped and not stripped.startswith("!"):
+                  lines[index] = "       250\tMonte-Carlo trials"
+                  break
+          path.write_text("\n".join(lines) + "\n")
+          PY
+
+          docker run --rm \
+            -v "$DATA_ROOT:/data" \
+            -v "$INPUT_ROOT:/input:ro" \
+            mc-single-arm:test \
+            mc-single-arm-run --input /input/smoke.inp --force
+
+          test -s "$DATA_ROOT/runout/smoke.out"
+          test -s "$DATA_ROOT/outfiles/smoke.out"
+          test -s "$DATA_ROOT/worksim/smoke.root"
+
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=sha,format=short,prefix=sha-
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Containerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,32 @@
+FROM rootproject/root:6.30.02-alma9
+
+LABEL org.opencontainers.image.title="mc-single-arm"
+LABEL org.opencontainers.image.description="Containerized Hall C mc-single-arm"
+LABEL org.opencontainers.image.source="https://github.com/JeffersonLab/mc-single-arm"
+
+RUN dnf install -y gcc-gfortran gcc-c++ make python3 pcre pcre-devel \
+    && dnf clean all
+
+WORKDIR /opt/mc-single-arm
+COPY . /opt/mc-single-arm
+
+RUN chmod +x /opt/mc-single-arm/bin/mc-single-arm-api /opt/mc-single-arm/bin/mc-single-arm-run \
+    && mkdir -p /data/infiles /data/outfiles /data/runout /data/worksim /opt/mc-single-arm/share \
+    && cp -r /opt/mc-single-arm/infiles /opt/mc-single-arm/share/infiles \
+    && rm -rf /opt/mc-single-arm/infiles /opt/mc-single-arm/outfiles /opt/mc-single-arm/runout /opt/mc-single-arm/worksim \
+    && ln -s /data/infiles /opt/mc-single-arm/infiles \
+    && ln -s /data/outfiles /opt/mc-single-arm/outfiles \
+    && ln -s /data/runout /opt/mc-single-arm/runout \
+    && ln -s /data/worksim /opt/mc-single-arm/worksim \
+    && cp -n /opt/mc-single-arm/share/infiles/*.inp /data/infiles/ \
+    && ROOT_PREFIX="$(root-config --prefix)" \
+    && make -C /opt/mc-single-arm/src clean all \
+    && make -C /opt/mc-single-arm/util/root_tree clean all ROOTSYS="$ROOT_PREFIX" \
+    && ln -s /opt/mc-single-arm/bin/mc-single-arm-api /usr/local/bin/mc-single-arm-api \
+    && ln -s /opt/mc-single-arm/bin/mc-single-arm-run /usr/local/bin/mc-single-arm-run
+
+ENV MC_SINGLE_ARM_APP_ROOT=/opt/mc-single-arm
+ENV MC_SINGLE_ARM_DATA_ROOT=/data
+
+VOLUME ["/data"]
+CMD ["mc-single-arm-run", "--help"]

--- a/README_container.md
+++ b/README_container.md
@@ -1,0 +1,107 @@
+# mc-single-arm container
+
+This container packages the existing Hall C `mc-single-arm` program with a small
+runner that keeps inputs and outputs in predictable container paths. The
+simulation code and existing Makefiles are unchanged.
+
+## Build locally with Docker
+
+```bash
+docker build -f Containerfile -t mc-single-arm:local .
+```
+
+## Inspect inputs
+
+```bash
+docker run --rm mc-single-arm:local mc-single-arm-api describe
+docker run --rm mc-single-arm:local mc-single-arm-api describe --format json
+docker run --rm mc-single-arm:local mc-single-arm-api describe --format yaml
+```
+
+The default text output lists input sections, keys, labels, defaults, and data
+types. It also lists bundled example input files. For the full input format,
+inspect the files in `infiles/` or the bundled container path
+`/opt/mc-single-arm/share/infiles`.
+
+## Run with Docker
+
+Create a writable output area on the host:
+
+```bash
+mkdir -p mc-data
+```
+
+Mount your input file into the container and pass its container-local path:
+
+```bash
+docker run --rm \
+  -v "$PWD/mc-data:/data" \
+  -v "$PWD/my_run.inp:/input/my_run.inp:ro" \
+  mc-single-arm:local \
+  mc-single-arm-run --input /input/my_run.inp
+```
+
+`--input` must be a path that exists inside the container. The runner copies
+that file to `/data/infiles/<basename>.inp` before launching `mc_single_arm`.
+
+Outputs are written under the mounted `/data` directory:
+
+- `runout/<basename>.out`
+- `outfiles/<basename>.out`
+- `worksim/<basename>.root`
+
+To run one of the bundled examples by name:
+
+```bash
+docker run --rm \
+  -v "$PWD/mc-data:/data" \
+  mc-single-arm:local \
+  mc-single-arm-run --basename shms_20deg_3gev_10cmtarg_cryo17
+```
+
+If `/data/infiles/<basename>.inp` is missing and the basename matches a bundled
+example, the runner copies that example from
+`/opt/mc-single-arm/share/infiles`.
+
+The program chooses its random seed from the clock and prints the seed in
+`runout/<basename>.out`. This container wrapper does not provide a seed option.
+
+## Overwrite behavior
+
+The runner checks for existing artifacts before writing:
+
+- `runout/<basename>.out`
+- `outfiles/<basename>.out`
+- `worksim/<basename>.root`
+- `worksim/<basename>.bin`
+
+In an interactive terminal, it prompts before overwriting. In noninteractive
+runs, it refuses to overwrite unless `--force` is supplied.
+
+## Apptainer
+
+Build a SIF from a local Docker image:
+
+```bash
+docker build -f Containerfile -t mc-single-arm:local .
+apptainer build --force mc-single-arm.sif docker-daemon://mc-single-arm:local
+```
+
+Run with a mounted data directory and an input file visible inside the
+container:
+
+```bash
+mkdir -p mc-data
+apptainer exec \
+  --bind "$PWD/mc-data:/data" \
+  --bind "$PWD/my_run.inp:/input/my_run.inp:ro" \
+  mc-single-arm.sif \
+  mc-single-arm-run --input /input/my_run.inp
+```
+
+Run a bundled example:
+
+```bash
+apptainer exec --bind "$PWD/mc-data:/data" mc-single-arm.sif \
+  mc-single-arm-run --basename shms_20deg_3gev_10cmtarg_cryo17
+```

--- a/README_container.md
+++ b/README_container.md
@@ -4,18 +4,27 @@ This container packages the existing Hall C `mc-single-arm` program with a small
 runner that keeps inputs and outputs in predictable container paths. The
 simulation code and existing Makefiles are unchanged.
 
-## Build locally with Docker
+## Choose a version
+
+Container images are published from git tags. Pick the tag you want from the
+GitHub tags page, then use that same tag as the container version:
+
+<https://github.com/JeffersonLab/mc-single-arm/tags>
+
+Examples below use:
 
 ```bash
-docker build -f Containerfile -t mc-single-arm:local .
+TAG=<tag_name>
+IMAGE=ghcr.io/jeffersonlab/mc-single-arm:$TAG
 ```
 
 ## Inspect inputs
 
 ```bash
-docker run --rm mc-single-arm:local mc-single-arm-api describe
-docker run --rm mc-single-arm:local mc-single-arm-api describe --format json
-docker run --rm mc-single-arm:local mc-single-arm-api describe --format yaml
+docker pull "$IMAGE"
+docker run --rm "$IMAGE" mc-single-arm-api describe
+docker run --rm "$IMAGE" mc-single-arm-api describe --format json
+docker run --rm "$IMAGE" mc-single-arm-api describe --format yaml
 ```
 
 The default text output lists input sections, keys, labels, defaults, and data
@@ -37,7 +46,7 @@ Mount your input file into the container and pass its container-local path:
 docker run --rm \
   -v "$PWD/mc-data:/data" \
   -v "$PWD/my_run.inp:/input/my_run.inp:ro" \
-  mc-single-arm:local \
+  "$IMAGE" \
   mc-single-arm-run --input /input/my_run.inp
 ```
 
@@ -55,7 +64,7 @@ To run one of the bundled examples by name:
 ```bash
 docker run --rm \
   -v "$PWD/mc-data:/data" \
-  mc-single-arm:local \
+  "$IMAGE" \
   mc-single-arm-run --basename shms_20deg_3gev_10cmtarg_cryo17
 ```
 
@@ -80,11 +89,12 @@ runs, it refuses to overwrite unless `--force` is supplied.
 
 ## Apptainer
 
-Build a SIF from a local Docker image:
+On JLab farm nodes, or any computer with access to the JLab CVMFS mount, tagged
+SIF images are available here:
 
 ```bash
-docker build -f Containerfile -t mc-single-arm:local .
-apptainer build --force mc-single-arm.sif docker-daemon://mc-single-arm:local
+TAG=<tag_name>
+SIF=/cvmfs/oasis.opensciencegrid.org/jlab/hallc/mc-single-arm/mc-single-arm-$TAG.sif
 ```
 
 Run with a mounted data directory and an input file visible inside the
@@ -95,13 +105,29 @@ mkdir -p mc-data
 apptainer exec \
   --bind "$PWD/mc-data:/data" \
   --bind "$PWD/my_run.inp:/input/my_run.inp:ro" \
-  mc-single-arm.sif \
+  "$SIF" \
   mc-single-arm-run --input /input/my_run.inp
 ```
 
 Run a bundled example:
 
 ```bash
-apptainer exec --bind "$PWD/mc-data:/data" mc-single-arm.sif \
+apptainer exec --bind "$PWD/mc-data:/data" "$SIF" \
   mc-single-arm-run --basename shms_20deg_3gev_10cmtarg_cryo17
+```
+
+## Build locally
+
+Most users should run a tagged image instead of building locally. To test local
+container changes:
+
+```bash
+docker build -f Containerfile -t mc-single-arm:local .
+docker run --rm mc-single-arm:local mc-single-arm-run --help
+```
+
+To build a local Apptainer image from that Docker image:
+
+```bash
+apptainer build --force mc-single-arm.sif docker-daemon://mc-single-arm:local
 ```

--- a/bin/mc-single-arm-api
+++ b/bin/mc-single-arm-api
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+
+APP_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SHARE_INFILES = APP_ROOT / "share" / "infiles"
+
+
+INPUT_SCHEMA: list[dict[str, Any]] = [
+    {"key": "n_trials", "label": "Monte-Carlo trials", "type": "integer", "default": 100000, "section": "Run Setup"},
+    {"key": "spectrometer", "label": "Spectrometer", "type": "enum", "default": 2, "section": "Run Setup", "choices": [{"value": 1, "label": "HMS"}, {"value": 2, "label": "SHMS"}]},
+    {"key": "spectrometer_momentum_mev", "label": "Spectrometer momentum", "type": "number", "default": 2000.0, "section": "Run Setup", "units": "MeV/c"},
+    {"key": "spectrometer_angle_deg", "label": "Spectrometer angle", "type": "number", "default": 20.0, "section": "Run Setup", "units": "deg"},
+    {"key": "dp_down_percent", "label": "M.C. dp/p down limit", "type": "number", "default": -15.0, "section": "Phase Space", "units": "%"},
+    {"key": "dp_up_percent", "label": "M.C. dp/p up limit", "type": "number", "default": 30.0, "section": "Phase Space", "units": "%"},
+    {"key": "theta_down_mr", "label": "M.C. theta down limit", "type": "number", "default": -55.0, "section": "Phase Space", "units": "mr"},
+    {"key": "theta_up_mr", "label": "M.C. theta up limit", "type": "number", "default": 55.0, "section": "Phase Space", "units": "mr"},
+    {"key": "phi_down_mr", "label": "M.C. phi down limit", "type": "number", "default": -50.0, "section": "Phase Space", "units": "mr"},
+    {"key": "phi_up_mr", "label": "M.C. phi up limit", "type": "number", "default": 50.0, "section": "Phase Space", "units": "mr"},
+    {"key": "beam_spot_horizontal_cm", "label": "Horizontal beam spot size", "type": "number", "default": 0.0, "section": "Beam And Target", "units": "cm"},
+    {"key": "beam_spot_vertical_cm", "label": "Vertical beam spot size", "type": "number", "default": 0.0, "section": "Beam And Target", "units": "cm"},
+    {"key": "target_length_cm", "label": "Target length", "type": "number", "default": 20.0, "section": "Beam And Target", "units": "cm"},
+    {"key": "raster_x_cm", "label": "Raster full-width x", "type": "number", "default": 0.0, "section": "Beam And Target", "units": "cm"},
+    {"key": "raster_y_cm", "label": "Raster full-width y", "type": "number", "default": 0.0, "section": "Beam And Target", "units": "cm"},
+    {"key": "cut_dpp_percent", "label": "dp/p reconstruction cut", "type": "number", "default": 100.0, "section": "Reconstruction Cuts", "units": "%"},
+    {"key": "cut_theta_mr", "label": "Theta reconstruction cut", "type": "number", "default": 100.0, "section": "Reconstruction Cuts", "units": "mr"},
+    {"key": "cut_phi_mr", "label": "Phi reconstruction cut", "type": "number", "default": 100.0, "section": "Reconstruction Cuts", "units": "mr"},
+    {"key": "cut_ztgt_cm", "label": "ZTGT reconstruction cut", "type": "number", "default": 100.0, "section": "Reconstruction Cuts", "units": "cm"},
+    {"key": "rad_len_cm", "label": "Radiation length of target material", "type": "number", "default": 866.0, "section": "Beam And Target", "units": "cm"},
+    {"key": "beam_x_offset_cm", "label": "Beam x offset", "type": "number", "default": 0.0, "section": "Offsets", "units": "cm"},
+    {"key": "beam_y_offset_cm", "label": "Beam y offset", "type": "number", "default": 0.0, "section": "Offsets", "units": "cm"},
+    {"key": "target_z_offset_cm", "label": "Target z offset", "type": "number", "default": 0.0, "section": "Offsets", "units": "cm"},
+    {"key": "spectrometer_x_offset_cm", "label": "Spectrometer x offset", "type": "number", "default": 0.0, "section": "Offsets", "units": "cm"},
+    {"key": "spectrometer_y_offset_cm", "label": "Spectrometer y offset", "type": "number", "default": 0.0, "section": "Offsets", "units": "cm"},
+    {"key": "spectrometer_z_offset_cm", "label": "Spectrometer z offset", "type": "number", "default": 0.0, "section": "Offsets", "units": "cm"},
+    {"key": "spectrometer_xp_offset_mr", "label": "Spectrometer xp offset", "type": "number", "default": 0.0, "section": "Offsets", "units": "mr"},
+    {"key": "spectrometer_yp_offset_mr", "label": "Spectrometer yp offset", "type": "number", "default": 0.0, "section": "Offsets", "units": "mr"},
+    {"key": "particle_id", "label": "Particle identification", "type": "enum", "default": 0, "section": "Physics Flags", "choices": [{"value": 0, "label": "Electron"}, {"value": 1, "label": "Proton"}, {"value": 2, "label": "Deuteron"}, {"value": 3, "label": "Pion"}, {"value": 4, "label": "Kaon"}]},
+    {"key": "multiple_scattering_flag", "label": "Multiple scattering", "type": "boolean", "default": True, "section": "Physics Flags"},
+    {"key": "wire_chamber_smearing_flag", "label": "Wire chamber smearing", "type": "boolean", "default": True, "section": "Physics Flags"},
+    {"key": "store_all_events_flag", "label": "Store all events", "type": "boolean", "default": True, "section": "Physics Flags"},
+    {"key": "beam_energy_mev", "label": "Beam energy", "type": "number", "default": 0.0, "section": "Optional", "units": "MeV"},
+    {"key": "use_sieve_flag", "label": "Use sieve", "type": "boolean", "default": False, "section": "Optional"},
+    {"key": "target_atomic_mass", "label": "Target atomic number", "type": "number", "default": 12.0, "section": "Optional"},
+]
+
+
+def infiles_root() -> Path:
+    if DEFAULT_SHARE_INFILES.exists():
+        return DEFAULT_SHARE_INFILES
+    return APP_ROOT / "infiles"
+
+
+def example_summary(path: Path) -> str:
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("!") and "----" not in stripped:
+            return stripped.lstrip("!").strip()
+    return path.stem
+
+
+def example_payloads() -> list[dict[str, str]]:
+    examples = []
+    for path in sorted(infiles_root().glob("*.inp")):
+        examples.append(
+            {
+                "name": path.name,
+                "path": f"infiles/{path.name}",
+                "summary": example_summary(path),
+                "content": path.read_text(encoding="utf-8", errors="replace"),
+            }
+        )
+    return examples
+
+
+def contract() -> dict[str, Any]:
+    return {
+        "analysis_id": "mc-single-arm",
+        "name": "Hall C mc-single-arm",
+        "version": "container-v1",
+        "input_schema": INPUT_SCHEMA,
+        "examples": example_payloads(),
+        "run": {
+            "command": "mc-single-arm-run --data-root /data --input /input/<file>.inp",
+            "mounts": [
+                {"path": "/data", "mode": "rw", "description": "Contains infiles, outfiles, runout, and worksim."},
+                {"path": "/input", "mode": "ro", "description": "Optional location for user-provided input files."},
+            ],
+            "input_filename": "infiles/<basename>.inp",
+            "seed_control": {
+                "user_settable": False,
+                "description": "mc-single-arm chooses a clock-time random seed and prints it in runout/<basename>.out.",
+                "log_pattern": r"Starting random number seed:\s*(\d+)",
+            },
+            "overwrite_policy": {
+                "mode": "prompt_or_force",
+                "description": "Existing run artifacts are not overwritten without an interactive confirmation or --force.",
+            },
+        },
+        "outputs": [
+            {"key": "rootfile", "path": "worksim/<basename>.root", "regenerable": True},
+            {"key": "runout", "path": "runout/<basename>.out", "regenerable": True},
+            {"key": "outfile", "path": "outfiles/<basename>.out", "regenerable": True},
+        ],
+    }
+
+
+def to_yaml(value: Any, indent: int = 0) -> str:
+    pad = " " * indent
+    if isinstance(value, dict):
+        lines = []
+        for key, item in value.items():
+            if isinstance(item, (dict, list)):
+                lines.append(f"{pad}{key}:")
+                lines.append(to_yaml(item, indent + 2))
+            else:
+                lines.append(f"{pad}{key}: {json.dumps(item)}")
+        return "\n".join(lines)
+    if isinstance(value, list):
+        lines = []
+        for item in value:
+            if isinstance(item, (dict, list)):
+                lines.append(f"{pad}-")
+                lines.append(to_yaml(item, indent + 2))
+            else:
+                lines.append(f"{pad}- {json.dumps(item)}")
+        return "\n".join(lines)
+    return f"{pad}{json.dumps(value)}"
+
+
+def format_default(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def to_text(payload: dict[str, Any]) -> str:
+    grouped: OrderedDict[str, list[dict[str, Any]]] = OrderedDict()
+    for field in payload["input_schema"]:
+        grouped.setdefault(field["section"], []).append(field)
+
+    lines = [
+        "mc-single-arm container description",
+        "",
+        "Run command:",
+        "  mc-single-arm-run --data-root /data --input /input/<file>.inp",
+        "  mc-single-arm-run --data-root /data --basename <example-name>",
+        "",
+        "Input schema:",
+    ]
+    for section, fields in grouped.items():
+        lines.extend(["", f"  {section}"])
+        for field in fields:
+            units = f" {field['units']}" if "units" in field else ""
+            lines.append(
+                "    {key:<32} {label:<38} default={default:<10} <{dtype}>{units}".format(
+                    key=field["key"],
+                    label=field["label"],
+                    default=format_default(field["default"]),
+                    dtype=field["type"],
+                    units=units,
+                ).rstrip()
+            )
+
+    lines.extend(
+        [
+            "",
+            "Example inputs:",
+            f"  Bundled examples are available inside the container at {infiles_root()}.",
+            "  The paths below are reported as infiles/<name> for callers that consume this description.",
+        ]
+    )
+    for example in payload["examples"]:
+        lines.append(f"  - {example['path']}: {example['summary']}")
+
+    lines.extend(
+        [
+            "",
+            "Outputs under /data:",
+            "  runout/<basename>.out",
+            "  outfiles/<basename>.out",
+            "  worksim/<basename>.root",
+            "",
+            "mc-single-arm chooses the random seed from the clock and reports it in the run log.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Describe the mc-single-arm container interface.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    describe = subparsers.add_parser("describe", help="Emit the container interface description.")
+    describe.add_argument("--format", choices=("text", "json", "yaml"), default="text")
+    args = parser.parse_args()
+
+    payload = contract()
+    if args.format == "json":
+        print(json.dumps(payload, indent=2))
+    elif args.format == "yaml":
+        print(to_yaml(payload))
+    else:
+        print(to_text(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/mc-single-arm-run
+++ b/bin/mc-single-arm-run
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="${MC_SINGLE_ARM_APP_ROOT:-/opt/mc-single-arm}"
+if [[ ! -d "$APP_ROOT/src" ]]; then
+  APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+DATA_ROOT="${MC_SINGLE_ARM_DATA_ROOT:-/data}"
+BASENAME=""
+INPUT_FILE=""
+CONVERT_ROOT=1
+KEEP_BIN=0
+FORCE=0
+
+usage() {
+  cat <<'USAGE'
+usage: mc-single-arm-run [--data-root DIR] (--input FILE | --basename NAME) [--no-root] [--keep-bin] [--force]
+
+Run mc-single-arm in a container-friendly directory layout.
+
+Options:
+  --input FILE      Input file path visible inside the container.
+  --basename NAME   Use /data/infiles/NAME.inp, or a bundled example with NAME.
+  --data-root DIR   Writable run directory containing infiles, outfiles, runout,
+                    and worksim. Default: /data.
+  --no-root         Skip conversion from worksim/NAME.bin to worksim/NAME.root.
+  --keep-bin        Keep worksim/NAME.bin after ROOT conversion.
+  --force           Overwrite existing output artifacts without prompting.
+  -h, --help        Show this help.
+
+Examples:
+  mc-single-arm-run --input /input/my_run.inp
+  mc-single-arm-run --basename shms_20deg_3gev_10cmtarg_cryo17
+
+For Docker, mount host files to container-local paths first, for example:
+  docker run --rm -v "$PWD/mc-data:/data" -v "$PWD/my_run.inp:/input/my_run.inp:ro" \
+    IMAGE mc-single-arm-run --input /input/my_run.inp
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --data-root) DATA_ROOT="$2"; shift 2 ;;
+    --basename) BASENAME="$2"; shift 2 ;;
+    --input) INPUT_FILE="$2"; shift 2 ;;
+    --no-root) CONVERT_ROOT=0; shift ;;
+    --keep-bin) KEEP_BIN=1; shift ;;
+    --force) FORCE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$DATA_ROOT"
+DATA_ROOT="$(cd "$DATA_ROOT" && pwd)"
+mkdir -p "$DATA_ROOT/infiles" "$DATA_ROOT/outfiles" "$DATA_ROOT/runout" "$DATA_ROOT/worksim"
+
+if [[ -n "$INPUT_FILE" ]]; then
+  if [[ ! -f "$INPUT_FILE" ]]; then
+    echo "input file not found inside container: $INPUT_FILE" >&2
+    exit 2
+  fi
+  BASENAME="$(basename "$INPUT_FILE")"
+  BASENAME="${BASENAME%.inp}"
+fi
+
+if [[ -z "$BASENAME" ]]; then
+  echo "either --input or --basename is required" >&2
+  exit 2
+fi
+BASENAME="$(basename "$BASENAME")"
+BASENAME="${BASENAME%.inp}"
+TARGET_INPUT="$DATA_ROOT/infiles/$BASENAME.inp"
+
+if [[ -n "$INPUT_FILE" ]]; then
+  input_real="$(readlink -f "$INPUT_FILE")"
+  target_real="$(readlink -m "$TARGET_INPUT")"
+  if [[ "$input_real" != "$target_real" ]]; then
+    cp "$INPUT_FILE" "$TARGET_INPUT"
+  fi
+elif [[ ! -f "$TARGET_INPUT" ]]; then
+  if [[ -f "$APP_ROOT/share/infiles/$BASENAME.inp" ]]; then
+    cp "$APP_ROOT/share/infiles/$BASENAME.inp" "$TARGET_INPUT"
+  else
+    echo "input file not found: $TARGET_INPUT" >&2
+    echo "Bundled examples are in $APP_ROOT/share/infiles." >&2
+    exit 2
+  fi
+fi
+
+conflicts=()
+for candidate in \
+  "$DATA_ROOT/runout/$BASENAME.out" \
+  "$DATA_ROOT/outfiles/$BASENAME.out" \
+  "$DATA_ROOT/worksim/$BASENAME.root" \
+  "$DATA_ROOT/worksim/$BASENAME.bin"; do
+  [[ -e "$candidate" ]] && conflicts+=("$candidate")
+done
+
+if [[ "${#conflicts[@]}" -gt 0 && "$FORCE" -ne 1 ]]; then
+  printf 'Refusing to overwrite existing run artifacts:\n' >&2
+  printf '  %s\n' "${conflicts[@]}" >&2
+  if [[ -t 0 && -t 1 ]]; then
+    read -r -p "Overwrite these files? Type 'yes' to continue: " answer
+    if [[ "$answer" != "yes" ]]; then
+      echo "Run canceled." >&2
+      exit 3
+    fi
+  else
+    echo "Use --force only when running in an isolated per-run directory." >&2
+    exit 3
+  fi
+fi
+
+if [[ ! -x "$APP_ROOT/src/mc_single_arm" ]]; then
+  make -C "$APP_ROOT/src" clean all
+fi
+
+WORK_ROOT="$APP_ROOT"
+RUN_VIEW=""
+if [[ "${MC_SINGLE_ARM_IN_PLACE:-0}" != "1" ]]; then
+  RUN_VIEW="$(mktemp -d "${TMPDIR:-/tmp}/mc-single-arm-run.XXXXXX")"
+  trap '[[ -n "$RUN_VIEW" ]] && rm -rf "$RUN_VIEW"' EXIT
+  cp -a "$APP_ROOT/src" "$RUN_VIEW/src"
+  mkdir -p "$RUN_VIEW/util"
+  cp -a "$APP_ROOT/util/root_tree" "$RUN_VIEW/util/root_tree"
+  ln -s "$DATA_ROOT/infiles" "$RUN_VIEW/infiles"
+  ln -s "$DATA_ROOT/outfiles" "$RUN_VIEW/outfiles"
+  ln -s "$DATA_ROOT/runout" "$RUN_VIEW/runout"
+  ln -s "$DATA_ROOT/worksim" "$RUN_VIEW/worksim"
+  WORK_ROOT="$RUN_VIEW"
+fi
+
+(
+  cd "$WORK_ROOT/src"
+  ./mc_single_arm <<EOF
+$BASENAME
+EOF
+) > "$DATA_ROOT/runout/$BASENAME.out" 2>&1
+
+if [[ "$CONVERT_ROOT" -eq 1 ]]; then
+  if [[ ! -x "$WORK_ROOT/util/root_tree/make_root_tree" ]]; then
+    ROOT_PREFIX="${ROOTSYS:-$(root-config --prefix)}"
+    make -C "$APP_ROOT/util/root_tree" clean all ROOTSYS="$ROOT_PREFIX"
+    if [[ "$WORK_ROOT" != "$APP_ROOT" ]]; then
+      cp "$APP_ROOT/util/root_tree/make_root_tree" "$WORK_ROOT/util/root_tree/make_root_tree"
+    fi
+  fi
+  (
+    cd "$WORK_ROOT/util/root_tree"
+    ./make_root_tree <<EOF
+$BASENAME
+EOF
+  ) >> "$DATA_ROOT/runout/$BASENAME.out" 2>&1
+  if [[ "$KEEP_BIN" -eq 0 ]]; then
+    rm -f "$DATA_ROOT/worksim/$BASENAME.bin"
+  fi
+fi
+
+echo "$DATA_ROOT/runout/$BASENAME.out"


### PR DESCRIPTION
Added a CI pipeline for building containers.  The .github/workflow/container.yml now builds and tests containers based on a tagged commit.  Development on mc-single-arm is currently spread through multiple branches and is not merged back into main.  Any tagged commit can now have a container made, and added to ghcr.io/JeffersonLab/mc-single-arm:<tag_name>.  Users can pull that specific tag to work with those features.

The location for mc-single-arm containers in ghcr.io is listed alongside the location in cvmfs for apptainer containers.

This PR does not modify any Makefile or Fortran code.